### PR TITLE
Set up Promptbook public foundation and starter collection

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,25 @@
+name: Validate Promptbook
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Validate public prompt contract
+        run: python scripts/validate_promptbook.py
+      - name: Run validator tests
+        run: python -m unittest discover -s tests -p 'test_*.py' -v

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Contributing to Promptbook
+
+Promptbook is a curated collection. A smaller set of prompts that solve real tasks clearly is more useful than a large catalogue of lightly tested prompt text.
+
+## What makes a good contribution?
+
+A new prompt should:
+
+- solve a concrete, reusable task;
+- be understandable without private conversational history;
+- make required inputs explicit;
+- keep the copy/paste prompt usable on its own;
+- state material boundaries and limitations;
+- avoid private data, credentials, internal URLs, repository-specific IDs, and organisation-specific assumptions unless the prompt explicitly targets that public system;
+- avoid unsupported claims such as “best practice”, “guaranteed”, or universal model portability;
+- stay as small as the intended behaviour permits;
+- include a concise example or evidence of use where practical.
+
+Use [`templates/prompt-template.md`](templates/prompt-template.md) as the starting shape.
+
+## Required prompt sections
+
+Published prompts must contain these headings in order:
+
+1. `Purpose`
+2. `When to use`
+3. `Prompt`
+4. `Inputs`
+5. `What it does`
+6. `Boundaries / limitations`
+7. `Status`
+
+Allowed status values are `experimental`, `tested`, and `stable`. See the root README for their meaning.
+
+## Pull requests
+
+Keep each pull request coherent and reviewable. Explain the reusable problem, why the prompt is needed, what evidence supports its status, and any important limitations. Prompt changes should preserve user-facing behaviour unless the PR intentionally changes it.
+
+Run before opening a PR:
+
+```bash
+python scripts/validate_promptbook.py
+python -m unittest discover -s tests -p 'test_*.py' -v
+```
+
+Normal PR validation runs the same checks automatically.
+
+## Improving an existing prompt
+
+Prefer fixing the smallest concrete problem. If a change materially alters the task, authority model, required inputs, or expected behaviour, explain that interface change rather than presenting it as wording cleanup.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,56 @@
-# promptbook
-Reusable prompts and workflows for disciplined, autonomous AI-assisted engineering
+# Promptbook
+
+A curated collection of practical prompts and workflows for reliable, evidence-driven agentic engineering.
+
+Promptbook is for engineers and technical practitioners who want AI assistants to do useful work with clear evidence, bounded authority, explicit failure behaviour, and less unnecessary human orchestration. It is intentionally small and curated rather than a dump of every prompt that might be useful.
+
+## Start here
+
+| Task | Prompt |
+| --- | --- |
+| Turn an issue into an implementation plan | [Plan an issue](prompts/engineering/plan-an-issue.md) |
+| Review a pull request substantively | [Review a pull request](prompts/engineering/pr-review.md) |
+| Continue governed work with minimal intervention | [Autonomous progression](prompts/workflows/autonomous-progression.md) |
+| Re-review work from a fresh context | [Fresh independent review](prompts/workflows/fresh-independent-review.md) |
+
+Browse the complete collection in [`prompts/`](prompts/README.md).
+
+## How to use Promptbook
+
+1. Open a prompt that matches the task you want to perform.
+2. Copy the text in its **Prompt** section.
+3. Replace the declared `<PLACEHOLDERS>` with your actual context.
+4. Give the prompt to the AI assistant or agent that has the capabilities needed for the task.
+5. Keep repository-local instructions, platform safety rules, and explicit task authority above generic Promptbook guidance.
+
+See [Using Promptbook](guides/using-promptbook.md) for copy, adaptation, and composition patterns.
+
+## What makes these prompts different?
+
+Promptbook prompts are designed around engineering behaviour rather than persona wording. They tend to make evidence, scope, validation, authority, negative paths, and stop conditions explicit. They also try to distinguish routine engineering judgement from decisions that genuinely require a human.
+
+The prompts are model-portable by default. A prompt may still require tools such as repository access, CI visibility, or file editing when the task itself requires them.
+
+## Status labels
+
+Every prompt has one maturity label:
+
+- **experimental** — a useful pattern with limited real-task evidence;
+- **tested** — exercised successfully on real tasks, with known limitations;
+- **stable** — repeatedly useful and intentionally maintained as a reusable interface.
+
+Status describes the evidence behind the Promptbook prompt. It is not a claim of universal model quality or best practice.
+
+## Guides
+
+- [Using Promptbook](guides/using-promptbook.md)
+- [Adapting prompts](guides/adapting-prompts.md)
+- [Design principles](guides/design-principles.md)
+
+## Contributing
+
+Contributions are welcome. Read [`CONTRIBUTING.md`](CONTRIBUTING.md) and start from the [prompt template](templates/prompt-template.md). New prompts should solve a concrete reusable task, be self-contained, and avoid private or organisation-specific identifiers.
+
+## Licence
+
+Promptbook is licensed under the [Apache License 2.0](LICENSE).

--- a/guides/adapting-prompts.md
+++ b/guides/adapting-prompts.md
@@ -1,0 +1,35 @@
+# Adapting prompts
+
+Promptbook prompts are starting contracts, not magic strings. Adapt them to your repository, toolset, and risk level while preserving the parts that carry decision value.
+
+## Safe things to change
+
+You can normally change:
+
+- tool and platform names;
+- branch, issue, or review conventions;
+- terminology and output formatting;
+- the amount of explanation requested;
+- validation commands and evidence sources;
+- whether a task records its result in an issue, PR, document, or only the current conversation.
+
+## Things to preserve deliberately
+
+Before removing a requirement, ask what failure it prevents. Common high-value invariants are:
+
+- reconstruct current state instead of trusting a stale summary;
+- distinguish observed evidence from inference;
+- keep the intended scope and non-goals visible;
+- prefer the smallest sufficient change;
+- validate the exact candidate that will be used or merged;
+- preserve failed and negative evidence;
+- stop on missing authority or material ambiguity instead of inventing an answer;
+- separate fresh review from author-side reasoning when independence matters.
+
+## Placeholders
+
+Use explicit uppercase placeholders such as `<ISSUE_OR_TASK>` or `<REVIEW_TARGET>`. Every placeholder used in the Prompt section must be explained in the Inputs section so a reader does not need hidden context.
+
+## When to split a prompt
+
+Split a prompt when two parts need materially different authority, evidence, or independence. Planning and implementation can be separate because implementation mutates state; author-side implementation and fresh substantive review can be separate because the latter requires independence.

--- a/guides/design-principles.md
+++ b/guides/design-principles.md
@@ -1,0 +1,35 @@
+# Design principles
+
+Promptbook is organised around observable engineering behaviour rather than elaborate personas.
+
+## Evidence before conclusion
+
+Ask the assistant to inspect the authoritative artefacts that can answer the question. Summaries and prior conclusions are useful navigation, but they should not silently replace the underlying candidate, repository state, tests, or governing record when those are available.
+
+## Bounded authority
+
+A prompt should not imply that access equals permission. Separate what the assistant can technically do from what the task or repository authorises it to do.
+
+## Minimum sufficient change
+
+Prefer the smallest coherent change that satisfies the intended outcome. Avoid opportunistic refactoring, speculative abstractions, new infrastructure, or adjacent work that is not needed for the task.
+
+## Fail closed where evidence matters
+
+When a material fact, identity, permission, or decision cannot be established, preserve the uncertainty. A blocked or incomplete result is better than a confident result manufactured from missing evidence.
+
+## Validation is part of the task
+
+Implementation is not complete because code was written. Review the complete diff, run the relevant checks, inspect negative paths, and verify any mutation before claiming success.
+
+## Independence when independence matters
+
+A fresh review should reconstruct the decision from the actual evidence rather than inheriting the authoring context's conclusion. Freshness is about prior-information boundaries, not a particular UI mode.
+
+## Minimise unnecessary human orchestration
+
+Routine engineering judgement, validation, bounded remediation, and other already-authorised work should not automatically become conversational stop points. Stop for genuine human decisions, unavailable capabilities, unsafe ambiguity, or completion.
+
+## Self-contained public prompts
+
+A public prompt should expose every material input a new user must provide. Hidden private history, internal IDs, secret tooling assumptions, and unexplained conventions make a prompt fragile and non-reusable.

--- a/guides/using-promptbook.md
+++ b/guides/using-promptbook.md
@@ -1,0 +1,29 @@
+# Using Promptbook
+
+Promptbook supports three simple usage modes: copy, adapt, and compose.
+
+## Copy and use
+
+Choose the prompt closest to your task, copy its **Prompt** section, and replace every declared placeholder with real context. Do not remove evidence, validation, authority, or stop requirements merely to make the prompt shorter unless they are genuinely irrelevant to your task.
+
+A prompt cannot provide capabilities the receiving assistant does not have. Repository review still requires repository access; implementation still requires an authorised write path; a fresh independent review still requires a context that has not inherited the earlier conclusion.
+
+## Adapt
+
+Adapt tool names, repository conventions, terminology, and output format freely. Preserve the behavioural invariants that make the prompt safe and useful: inspect current evidence, keep scope bounded, make assumptions explicit, validate results, and stop rather than invent missing authority or facts.
+
+See [Adapting prompts](adapting-prompts.md) for a more detailed checklist.
+
+## Compose
+
+Composition works best when prompts have different responsibilities. For example, use an implementation-planning prompt first and a fresh-review prompt later. Avoid concatenating several large prompts that each try to control the entire lifecycle; overlapping authority and stop rules can become contradictory.
+
+When guidance conflicts, apply this precedence:
+
+1. platform and safety constraints;
+2. explicit user/task authority;
+3. repository-local instructions and policies;
+4. the task-specific prompt;
+5. generic Promptbook guidance.
+
+If the conflict changes what is authorised or materially changes the intended outcome, resolve it explicitly rather than silently choosing the most convenient instruction.

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -1,0 +1,22 @@
+# Prompts
+
+Promptbook is organised by the task a user wants to perform.
+
+## Engineering
+
+- [Plan an issue](engineering/plan-an-issue.md)
+- [Implement an approved issue](engineering/implement-an-approved-issue.md)
+- [Review a pull request](engineering/pr-review.md)
+- [Remediate review findings](engineering/remediate-review-findings.md)
+
+## Workflows
+
+- [Autonomous progression](workflows/autonomous-progression.md)
+- [Fresh independent review](workflows/fresh-independent-review.md)
+- [Next-session handover](workflows/next-session-handover.md)
+
+## Documentation
+
+- [Repository documentation assessment](documentation/repository-assessment.md)
+
+New categories should be added only when they contain a real reusable prompt, not to reserve taxonomy in advance.

--- a/prompts/documentation/repository-assessment.md
+++ b/prompts/documentation/repository-assessment.md
@@ -1,0 +1,51 @@
+# Repository documentation assessment
+
+## Purpose
+
+Assess whether repository documentation lets a defined reader complete a real task safely, rather than reviewing documentation for style or coverage in the abstract.
+
+## When to use
+
+Use when you need evidence about navigation, authority, missing/contradictory documentation, or the smallest useful documentation improvement for a repository task.
+
+## Prompt
+
+```text
+Assess the documentation in <REPOSITORY_OR_DOCSET> for <READER_TASK>.
+
+Start from the entry point a real reader would reasonably receive. Follow the documented path rather than searching broadly for the answer first.
+
+For each material conclusion, distinguish:
+- Observation — what the documentation/repository explicitly shows;
+- Authority — which source controls the decision when sources differ;
+- Inference — a conclusion supported by evidence but not stated directly;
+- Uncertainty — information that cannot be established safely from the available documentation.
+
+Determine:
+1. whether the reader can complete the task from the documented path;
+2. where navigation becomes ambiguous, stale, contradictory, or incomplete;
+3. whether a higher-authority repository source resolves the ambiguity;
+4. what useful existing material should be retained;
+5. the smallest response justified by the evidence: no change, navigation improvement, correction, new explanation, or an explicit authority/decision gap.
+
+Do not invent undocumented intent, policy, ownership, rationale, or product decisions. Do not draft a large documentation rewrite when the observed reader failure is narrower.
+
+Return one primary result: COMPLETE, PARTIAL, BLOCKED, or NOT TESTED, with concise evidence and the smallest sufficient next action.
+```
+
+## Inputs
+
+- `<REPOSITORY_OR_DOCSET>` — the repository or bounded documentation set to assess.
+- `<READER_TASK>` — the concrete task a named reader should be able to complete.
+
+## What it does
+
+Evaluates documentation through an actual task path, preserves authority boundaries, and allows “no change” or “blocked by missing decision” to be valid outcomes.
+
+## Boundaries / limitations
+
+This is an assessment prompt, not automatic remediation authority. The quality of the result depends on a realistic reader task and access to the documentation sources that actually govern it.
+
+## Status
+
+`experimental`

--- a/prompts/engineering/implement-an-approved-issue.md
+++ b/prompts/engineering/implement-an-approved-issue.md
@@ -1,0 +1,50 @@
+# Implement an approved issue
+
+## Purpose
+
+Implement a bounded task from an accepted plan while preserving scope, traceability, and validation discipline.
+
+## When to use
+
+Use when the intended outcome and implementation approach are already approved or otherwise sufficiently determined, and the receiving agent has an authorised repository write path.
+
+## Prompt
+
+```text
+Implement <APPROVED_TASK> using <APPROVED_PLAN>.
+
+Before modifying anything, inspect the current task and acceptance criteria, the approved plan, relevant repository instructions, architecture, code, tests, branch state, and any material changes since the plan was accepted.
+
+If current evidence materially invalidates the plan, stop before speculative mutation and state the smallest decision or replanning step required.
+
+Otherwise implement the smallest sufficient change. Preserve existing architecture and conventions unless the plan explicitly changes them. Add or update tests with behavioural changes, cover relevant negative paths, validate incrementally, and avoid unrelated refactoring or opportunistic dependency changes. Do not weaken tests, assertions, thresholds, or checks to make the candidate pass.
+
+Before declaring completion:
+1. inspect the complete diff;
+2. map the result back to every acceptance criterion;
+3. check for scope expansion, generated artefacts, secrets, and unrelated changes;
+4. run all relevant tests, static checks, builds, and required integration/manual validation;
+5. verify compatibility, migration, rollback, and residual risks;
+6. leave the candidate in a coherent reviewable state.
+
+Return a concise implementation record: outcome delivered, principal changes, acceptance-criterion coverage, validation and results, justified plan deviations, and remaining limitations.
+
+Do not merge, deploy, release, or broaden scope unless that action is already authorised separately.
+```
+
+## Inputs
+
+- `<APPROVED_TASK>` — the issue, task, or bounded implementation objective.
+- `<APPROVED_PLAN>` — the accepted implementation plan or exact reference to it.
+
+## What it does
+
+Keeps implementation tied to the approved outcome, makes validation part of completion, and forces plan drift to be reconciled before speculative code changes.
+
+## Boundaries / limitations
+
+This prompt does not grant repository mutation, merge, deployment, credential, or production authority. The receiving environment must already have those capabilities and permissions where needed.
+
+## Status
+
+`tested`

--- a/prompts/engineering/plan-an-issue.md
+++ b/prompts/engineering/plan-an-issue.md
@@ -1,0 +1,48 @@
+# Plan an issue
+
+## Purpose
+
+Turn a sufficiently shaped issue or task into a bounded, evidence-backed implementation plan.
+
+## When to use
+
+Use before implementation when the desired outcome is known but the technical approach, affected components, validation, or delivery sequence still needs to be worked out.
+
+## Prompt
+
+```text
+Act as the principal engineer planning <ISSUE_OR_TASK> for implementation.
+
+Inspect the complete task, relevant discussion, current repository architecture, code, tests, configuration, existing implementation patterns, related accepted decisions, and available validation/CI mechanisms.
+
+First decide whether the task is sufficiently shaped. If a material product, architecture, ownership, security, or scope decision prevents a credible plan, identify that blocker instead of inventing an answer.
+
+Otherwise produce the smallest sufficient implementation plan covering:
+- intended outcome, scope, and non-goals;
+- repository evidence and constraints that shape the design;
+- principal implementation decisions and affected components/files;
+- ordered implementation steps and dependencies;
+- mapping from acceptance criteria to implementation and proof;
+- tests, validation, negative paths, and operational evidence;
+- compatibility, migration, rollback, security, reliability, and maintainability risks;
+- assumptions, deferred work, and unresolved decisions;
+- whether the work is one coherent change or should be decomposed.
+
+Do not begin implementation while planning. End with one disposition: READY FOR IMPLEMENTATION, BLOCKED PENDING DECISION/EVIDENCE, or DECOMPOSE BEFORE IMPLEMENTATION.
+```
+
+## Inputs
+
+- `<ISSUE_OR_TASK>` — the issue URL/number, specification, or task statement to plan.
+
+## What it does
+
+Forces the plan to be grounded in current repository evidence and ties each acceptance criterion to both work and validation rather than producing a generic checklist.
+
+## Boundaries / limitations
+
+The prompt does not resolve genuinely missing product or authority decisions. It assumes the assistant can inspect the relevant repository or that the user supplies equivalent evidence.
+
+## Status
+
+`tested`

--- a/prompts/engineering/pr-review.md
+++ b/prompts/engineering/pr-review.md
@@ -1,0 +1,47 @@
+# Review a pull request
+
+## Purpose
+
+Perform a substantive engineering review of a pull request against its intended outcome and current evidence.
+
+## When to use
+
+Use for code, configuration, documentation, or workflow changes when the reviewer can inspect the complete candidate and its linked requirements.
+
+## Prompt
+
+```text
+Act as the principal engineer reviewing <PULL_REQUEST>.
+
+Inspect the complete current diff, linked issue/specification, accepted design or implementation plan when available, unresolved review threads, relevant repository conventions, and current CI/test/validation results.
+
+Review for correctness, completeness, requirement alignment, unintended scope expansion, regressions, edge cases, security and operational risk, maintainability, compatibility, test quality, documentation, migration, and rollback implications.
+
+Specifically verify that:
+- the change delivers the promised outcome rather than merely changing code;
+- unrelated refactoring or speculative improvements have not entered the candidate;
+- validation is sufficient for the risks introduced;
+- tests prove the required behaviour and important negative paths;
+- tests, assertions, thresholds, or checks were not weakened or bypassed;
+- automated success is not masking an unresolved functional problem.
+
+Distinguish blockers from non-blocking observations, questions, optional suggestions, and follow-up ideas. Prefer concrete, evidence-backed findings over stylistic preference.
+
+Conclude with exactly one disposition: APPROVED, CHANGES REQUIRED, or CANNOT ASSESS. For CHANGES REQUIRED, list blocking findings only after the concise rationale.
+```
+
+## Inputs
+
+- `<PULL_REQUEST>` — the PR URL/number and repository context if it is not otherwise available.
+
+## What it does
+
+Shifts review from line-by-line style commentary toward outcome, contract, risk, and proof while still permitting precise findings where they matter.
+
+## Boundaries / limitations
+
+A useful review requires access to the actual candidate and decision-critical evidence. Do not claim independent review if the context substantially authored the candidate or inherited its substantive conclusion.
+
+## Status
+
+`tested`

--- a/prompts/engineering/remediate-review-findings.md
+++ b/prompts/engineering/remediate-review-findings.md
@@ -1,0 +1,44 @@
+# Remediate review findings
+
+## Purpose
+
+Turn blocking review findings into the minimum safe correction without reopening unrelated design work.
+
+## When to use
+
+Use after a substantive review has identified concrete defects and the existing task or design already determines the intended behaviour closely enough to repair them.
+
+## Prompt
+
+```text
+Remediate the blocking findings on <REVIEWED_CANDIDATE>.
+
+First re-read the exact findings, the governing task/design, and the current candidate. Classify each finding as:
+- valid and bounded by the existing contract;
+- invalid or already resolved by current evidence; or
+- requiring a genuinely new product, architecture, authority, or scope decision.
+
+For every valid bounded finding, derive the smallest safe correction. Do not broaden scope, redesign adjacent components, weaken validation, or treat review suggestions as requirements unless the governing contract makes them necessary.
+
+Implement the bounded corrections, add or adjust regression coverage that would have caught the defect, run the relevant validation, and inspect the complete resulting diff for accidental scope expansion.
+
+Return a remediation record mapping each blocking finding to the change and proof that resolves it. Clearly identify any finding that still requires a separate decision rather than pretending remediation is complete.
+
+Preserve any required independent re-review boundary; do not present author-side remediation as fresh approval evidence.
+```
+
+## Inputs
+
+- `<REVIEWED_CANDIDATE>` — the PR/branch/candidate plus the blocking review findings.
+
+## What it does
+
+Keeps remediation narrow, makes review findings traceable to regression evidence, and prevents a repair cycle from becoming an unbounded redesign.
+
+## Boundaries / limitations
+
+Use only where the expected correction is objectively bounded by existing requirements. Materially new architecture, authority, security, product, or scope decisions should be resolved separately.
+
+## Status
+
+`tested`

--- a/prompts/workflows/autonomous-progression.md
+++ b/prompts/workflows/autonomous-progression.md
@@ -1,0 +1,51 @@
+# Autonomous progression
+
+## Purpose
+
+Let an engineering agent continue routine, already-authorised work without repeatedly returning to the human for orchestration.
+
+## When to use
+
+Use for a governed engineering objective where repository policy, current evidence, and existing authority determine most routine next actions, but explicit stop boundaries still matter.
+
+## Prompt
+
+```text
+Progress <TASK_OR_OBJECTIVE> as far as safely possible with minimal human intervention.
+
+Treat repository-local instructions, explicit task authority, accepted plans/decisions, current evidence, and platform safety constraints as authoritative.
+
+Continue autonomously while the next action is:
+1. inside the current objective and scope;
+2. supported by sufficiently current evidence;
+3. safely decidable from existing policy, constraints, acceptance criteria, or minimum-safe-change principles; and
+4. executable with capabilities legitimately available in the current environment.
+
+Routine planning, implementation, validation, bounded remediation, review disposition, branch/PR work, merge where already authorised, post-merge verification, and close-out are not conversational stop points merely because they are the “next gate”. Refresh material state before consequential actions and reconcile changes rather than blindly executing stale instructions.
+
+Escalate only as one of these states:
+- EXTERNAL_REQUIRED — a required action cannot be performed in this environment, but a complete executable handoff can resolve it;
+- DECISION_REQUIRED — a genuine human judgement/authority decision is needed, such as material scope/outcome/architecture change, permission broadening, security weakening, destructive/production action, material cost, or acceptance of a known failed control;
+- BLOCKED — no safe action, external handoff, or concrete human decision can resolve the condition now;
+- COMPLETE — the governed objective is genuinely finished and required verification/close-out is done.
+
+When a bounded defect has an objectively determined minimum-safe remediation inside the existing contract, remediate and validate it without asking for another routine approval. Do not invent adjacent work merely to keep moving.
+
+Before ending, state why stopping is necessary. If none of EXTERNAL_REQUIRED, DECISION_REQUIRED, BLOCKED, or COMPLETE applies, continue the next authorised action.
+```
+
+## Inputs
+
+- `<TASK_OR_OBJECTIVE>` — the bounded engineering objective and any relevant governing issue/plan/reference.
+
+## What it does
+
+Separates genuine human decisions and capability boundaries from ordinary lifecycle status, reducing repeated “proceed?” interactions while retaining fail-closed behaviour.
+
+## Boundaries / limitations
+
+This prompt never overrides repository-local policy or grants credentials, production authority, destructive-action authority, or permission to widen scope. Autonomy is limited to actions already justified by the governing objective and evidence.
+
+## Status
+
+`tested`

--- a/prompts/workflows/fresh-independent-review.md
+++ b/prompts/workflows/fresh-independent-review.md
@@ -1,0 +1,40 @@
+# Fresh independent review
+
+## Purpose
+
+Review a candidate, design, or evidence record from a genuinely fresh context without inheriting the previous session's substantive conclusion.
+
+## When to use
+
+Use when independence is part of the quality or governance boundary: substantive PR review, design review, evidence adjudication, close-out review, or another decision where author-side reasoning should not be treated as approval evidence.
+
+## Prompt
+
+```text
+Conduct a fresh independent review of <REVIEW_TARGET> against <GOVERNING_CONTRACT>.
+
+Treat prior summaries, recommendations, and conclusions only as navigation aids. Reconstruct the material authoritative state directly from the actual candidate and decision-critical evidence. Establish the current identities, revisions, checks, review state, and governing requirements needed for this decision.
+
+Reach the substantive conclusion from freshly inspected evidence. Do not inherit the prior session's approval/rejection reasoning, do not weaken the governing contract to obtain approval, and distinguish blocking findings from non-blocking observations.
+
+If expected state changed, determine what changed and whether the review remains safely decidable; do not fail mechanically merely because an identity moved when the governing contract permits reconciliation.
+
+Return exactly one clear disposition appropriate to the gate (for example APPROVED / CHANGES REQUIRED), followed by concise decisive rationale. For a negative disposition, identify only material blockers that must be resolved.
+```
+
+## Inputs
+
+- `<REVIEW_TARGET>` — the exact PR, commit, design, evidence record, or other candidate to assess.
+- `<GOVERNING_CONTRACT>` — the issue, specification, acceptance criteria, design, policy, or explicit review contract.
+
+## What it does
+
+Creates an information boundary between authoring and adjudication and forces the reviewer to inspect the real evidence rather than merely validating a handover summary.
+
+## Boundaries / limitations
+
+Freshness is a property of prior information, not a prompt incantation. A context that substantially authored the candidate or already saw the expected answer cannot become independent merely by being told to forget it.
+
+## Status
+
+`tested`

--- a/prompts/workflows/next-session-handover.md
+++ b/prompts/workflows/next-session-handover.md
@@ -1,0 +1,46 @@
+# Next-session handover
+
+## Purpose
+
+Produce a compact, executable prompt that lets another chat or agent continue the current work without reconstructing unnecessary history.
+
+## When to use
+
+Use at a real context or capability boundary: fresh review, a new chat/session, a different agent, or an external execution environment.
+
+## Prompt
+
+```text
+Create the shortest safe handover prompt for continuing <CURRENT_WORK> in a new context.
+
+Preserve only information that materially affects the next decision or action. Include:
+- repository/system and governing issue/task identity;
+- exact current revision/head/base or other immutable identity when decision-critical;
+- the next bounded objective;
+- current authority and scope;
+- required evidence the new context must reconstruct or verify;
+- explicit prohibitions and stop conditions that still matter;
+- exact validation/evidence expected from the next step;
+- whether the new context must be genuinely fresh and, if so, what prior-information boundary must be preserved;
+- continuation semantics after success.
+
+Remove duplicated historical narrative, superseded identities, old run details that do not affect the next decision, and conclusions the fresh context must independently determine.
+
+The resulting handover must be directly copyable as the next prompt. Do not require the recipient to ask what to do next or search the previous conversation for missing instructions.
+```
+
+## Inputs
+
+- `<CURRENT_WORK>` — the present task state, including the next real boundary and any decision-critical identities.
+
+## What it does
+
+Turns a long working session into a minimal continuation contract while preserving the evidence and authority needed to avoid unsafe guessing.
+
+## Boundaries / limitations
+
+Do not use handover compression to omit active blockers, required authority, security boundaries, or identities that the next decision genuinely depends on.
+
+## Status
+
+`tested`

--- a/scripts/validate_promptbook.py
+++ b/scripts/validate_promptbook.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Dependency-free structural validation for Promptbook."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from urllib.parse import unquote
+
+ROOT = Path(__file__).resolve().parents[1]
+PROMPTS = ROOT / "prompts"
+REQUIRED_ROOT = ["README.md", "CONTRIBUTING.md", "LICENSE", "templates/prompt-template.md"]
+REQUIRED_HEADINGS = [
+    "Purpose",
+    "When to use",
+    "Prompt",
+    "Inputs",
+    "What it does",
+    "Boundaries / limitations",
+    "Status",
+]
+ALLOWED_STATUS = {"experimental", "tested", "stable"}
+PLACEHOLDER_RE = re.compile(r"<[A-Z][A-Z0-9_]*>")
+LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+PRIVATE_PATTERNS = {
+    "private source repository name": "ai-prompt-library",
+    "GitHub classic token prefix": "ghp_",
+    "GitHub fine-grained token prefix": "github_pat_",
+    "private image host": "private-user-images.githubusercontent.com",
+    "private key marker": "BEGIN OPENSSH PRIVATE KEY",
+}
+
+
+def section(text: str, heading: str) -> str:
+    marker = f"## {heading}"
+    start = text.find(marker)
+    if start < 0:
+        return ""
+    start += len(marker)
+    next_heading = text.find("\n## ", start)
+    return text[start:] if next_heading < 0 else text[start:next_heading]
+
+
+def validate_prompt_file(path: Path) -> list[str]:
+    errors: list[str] = []
+    text = path.read_text(encoding="utf-8")
+
+    positions = []
+    for heading in REQUIRED_HEADINGS:
+        marker = f"## {heading}"
+        pos = text.find(marker)
+        if pos < 0:
+            errors.append(f"{path}: missing heading {marker}")
+        positions.append(pos)
+    present = [pos for pos in positions if pos >= 0]
+    if present != sorted(present):
+        errors.append(f"{path}: required headings are out of order")
+
+    status_lines = [line.strip().strip("`") for line in section(text, "Status").splitlines() if line.strip()]
+    if not status_lines or status_lines[0] not in ALLOWED_STATUS:
+        errors.append(f"{path}: status must be one of {sorted(ALLOWED_STATUS)}")
+
+    prompt_text = section(text, "Prompt")
+    inputs_text = section(text, "Inputs")
+    for placeholder in sorted(set(PLACEHOLDER_RE.findall(prompt_text))):
+        if placeholder not in inputs_text:
+            errors.append(f"{path}: placeholder {placeholder} is not declared in Inputs")
+
+    if any(token in text for token in ("TODO", "TBD", "FIXME")):
+        errors.append(f"{path}: unresolved TODO/TBD/FIXME marker")
+
+    return errors
+
+
+def validate_text_safety(path: Path, text: str) -> list[str]:
+    errors: list[str] = []
+    for label, pattern in PRIVATE_PATTERNS.items():
+        if pattern in text:
+            errors.append(f"{path}: contains forbidden {label}")
+    return errors
+
+
+def validate_links(path: Path, text: str, root: Path) -> list[str]:
+    errors: list[str] = []
+    for raw in LINK_RE.findall(text):
+        target = raw.split("#", 1)[0].strip()
+        if not target or target.startswith(("http://", "https://", "mailto:")):
+            continue
+        target = unquote(target)
+        resolved = (path.parent / target).resolve()
+        try:
+            resolved.relative_to(root.resolve())
+        except ValueError:
+            errors.append(f"{path}: link escapes repository: {raw}")
+            continue
+        if not resolved.exists():
+            errors.append(f"{path}: broken repository link: {raw}")
+    return errors
+
+
+def validate_repository(root: Path = ROOT) -> list[str]:
+    errors: list[str] = []
+    for relative in REQUIRED_ROOT:
+        if not (root / relative).exists():
+            errors.append(f"missing required path: {relative}")
+
+    prompt_root = root / "prompts"
+    prompt_files = sorted(
+        path for path in prompt_root.rglob("*.md") if path.name != "README.md"
+    ) if prompt_root.exists() else []
+    if len(prompt_files) < 8:
+        errors.append(f"expected at least 8 published prompts, found {len(prompt_files)}")
+
+    for path in prompt_files:
+        errors.extend(validate_prompt_file(path))
+
+    for path in sorted(root.rglob("*.md")):
+        text = path.read_text(encoding="utf-8")
+        errors.extend(validate_text_safety(path, text))
+        errors.extend(validate_links(path, text, root))
+
+    return errors
+
+
+def main() -> int:
+    errors = validate_repository()
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        return 1
+    print("Promptbook validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/prompt-template.md
+++ b/templates/prompt-template.md
@@ -1,0 +1,32 @@
+# <PROMPT_TITLE>
+
+## Purpose
+
+Describe the concrete reusable outcome this prompt is intended to produce.
+
+## When to use
+
+Describe appropriate situations, prerequisites, and when another prompt would be more suitable.
+
+## Prompt
+
+```text
+Write the copy/paste-ready prompt here.
+Use explicit placeholders such as <TARGET> for context the user must provide.
+```
+
+## Inputs
+
+- `<TARGET>` — explain exactly what the user should provide.
+
+## What it does
+
+Describe the important observable behaviour, not just the requested output format.
+
+## Boundaries / limitations
+
+State important non-goals, capabilities the prompt cannot create, and conditions where the assistant should stop rather than infer.
+
+## Status
+
+`experimental`

--- a/tests/test_validate_promptbook.py
+++ b/tests/test_validate_promptbook.py
@@ -1,0 +1,55 @@
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "validate_promptbook", ROOT / "scripts" / "validate_promptbook.py"
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+class PromptbookValidationTests(unittest.TestCase):
+    def test_repository_is_valid(self):
+        self.assertEqual([], MODULE.validate_repository(ROOT))
+
+    def test_unknown_status_is_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "prompt.md"
+            path.write_text(
+                "# Test\n\n"
+                "## Purpose\nX\n\n## When to use\nX\n\n"
+                "## Prompt\n```text\nDo X\n```\n\n"
+                "## Inputs\nNone.\n\n## What it does\nX\n\n"
+                "## Boundaries / limitations\nX\n\n## Status\n`unknown`\n",
+                encoding="utf-8",
+            )
+            errors = MODULE.validate_prompt_file(path)
+            self.assertTrue(any("status must be one of" in error for error in errors))
+
+    def test_undeclared_placeholder_is_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "prompt.md"
+            path.write_text(
+                "# Test\n\n"
+                "## Purpose\nX\n\n## When to use\nX\n\n"
+                "## Prompt\n```text\nReview <TARGET>\n```\n\n"
+                "## Inputs\nNone.\n\n## What it does\nX\n\n"
+                "## Boundaries / limitations\nX\n\n## Status\n`tested`\n",
+                encoding="utf-8",
+            )
+            errors = MODULE.validate_prompt_file(path)
+            self.assertTrue(any("placeholder <TARGET>" in error for error in errors))
+
+    def test_private_identifier_is_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "doc.md"
+            errors = MODULE.validate_text_safety(path, "source: ai-prompt-library")
+            self.assertTrue(errors)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1

## Summary

Establishes Promptbook as a curated public prompt collection rather than a mirror of any private working library.

This candidate adds:

- a public-facing README and contribution contract;
- usage, adaptation, and design-principle guides;
- a lightweight prompt template and task-oriented prompt index;
- eight starter prompts covering planning, implementation, PR review, bounded remediation, autonomous progression, fresh independent review, session handover, and repository documentation assessment;
- dependency-free structural/public-safety validation;
- unit tests for the validator;
- a GitHub Actions workflow that runs the same validation on PRs and `main`.

## Public prompt contract

Every published prompt contains:

- Purpose
- When to use
- Prompt
- Inputs
- What it does
- Boundaries / limitations
- Status

Status is limited to `experimental`, `tested`, or `stable`.

## Public-safety boundary

The candidate contains no dependency on private repository access or private history. The validator rejects known private-source identifiers, common GitHub token prefixes, private image-host references, and undeclared Prompt placeholders.

## Candidate

- base: `b48769c70520d78de1df12a00029e72492f67c0a`
- exact head: `dd67fee5abb578be2be50d6611b00d4c65a3c3fd`
- one atomic commit

## Validation

- exact-head PR validation: `31936262138` — success;
- author-side public-only usability pass: no blockers;
- merged `main`: `b0ad5ffa57d76b51f129702367217067cd49fc51`;
- post-merge validation: `31936301801` — success.

Issue #1 remains the v0.1 setup control until the separately created GitHub Release `v0.1.0` is reconciled.