### PR TITLE
Add canonical public workflow router

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ Promptbook is for engineers and technical practitioners who want AI assistants t
 | --- | --- |
 | Turn an issue into an implementation plan | [Plan an issue](prompts/engineering/plan-an-issue.md) |
 | Review a pull request substantively | [Review a pull request](prompts/engineering/pr-review.md) |
-| Continue governed work with minimal intervention | [Autonomous progression](prompts/workflows/autonomous-progression.md) |
+| Continue governed work or determine the next workflow | [Workflow router](prompts/workflows/README.md) |
 | Re-review work from a fresh context | [Fresh independent review](prompts/workflows/fresh-independent-review.md) |
 
 Browse the complete collection in [`prompts/`](prompts/README.md).
 
 ## How to use Promptbook
 
-1. Open a prompt that matches the task you want to perform.
-2. Copy the text in its **Prompt** section.
-3. Replace the declared `<PLACEHOLDERS>` with your actual context.
+1. Open a prompt that matches the task you want to perform, or start from the [workflow router](prompts/workflows/README.md) when the next governed workflow should be selected from current state.
+2. Copy the text in its **Prompt** section when using an individual prompt, or follow the router invocation when using the workflow entrypoint.
+3. Replace the declared `<PLACEHOLDERS>` with your actual context where applicable.
 4. Give the prompt to the AI assistant or agent that has the capabilities needed for the task.
 5. Keep repository-local instructions, platform safety rules, and explicit task authority above generic Promptbook guidance.
 

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -11,6 +11,7 @@ Promptbook is organised by the task a user wants to perform.
 
 ## Workflows
 
+- [Workflow router — start here for governed continuation](workflows/README.md)
 - [Autonomous progression](workflows/autonomous-progression.md)
 - [Fresh independent review](workflows/fresh-independent-review.md)
 - [Next-session handover](workflows/next-session-handover.md)

--- a/prompts/workflows/README.md
+++ b/prompts/workflows/README.md
@@ -31,9 +31,9 @@ Use the first matching case:
 1. **A handover or next-session prompt is explicitly the requested deliverable** → [Next-session handover](next-session-handover.md).
    - Produce the handover only. Do not reinterpret a request for a prompt as authority to execute the handed-off task in the current context.
 
-2. **The current context is genuinely fresh and an independent substantive review is required now** → [Fresh independent review](fresh-independent-review.md).
-   - Reconstruct the decision from the actual candidate and evidence rather than inheriting the authoring conclusion.
-   - If independence is required but the current context is not genuinely fresh, use the handover workflow to produce a complete fresh-context review handoff and stop as `EXTERNAL_REQUIRED`.
+2. **An independent substantive review is required now**.
+   - If the current context is genuinely fresh for that decision → [Fresh independent review](fresh-independent-review.md). Reconstruct the decision from the actual candidate and evidence rather than inheriting the authoring conclusion.
+   - If the current context is not genuinely fresh → [Next-session handover](next-session-handover.md). Produce a complete fresh-context review handoff and stop as `EXTERNAL_REQUIRED`; do not substitute author-side reasoning for independent evidence.
 
 3. **A newly supplied bounded approval or execution authority applies to the current proposal or action** → [Autonomous progression](autonomous-progression.md).
    - Identify the exact proposal or action being authorised.
@@ -50,7 +50,7 @@ Use the first matching case:
 
 ## Terminal states
 
-A workflow should stop only as one of these states:
+A routed task should end only as one of these states:
 
 - `EXTERNAL_REQUIRED` — the next required action cannot legitimately be performed in the current environment, but a complete executable handoff can resolve it.
 - `DECISION_REQUIRED` — a genuine human judgement or authority decision is required.
@@ -67,7 +67,7 @@ Review readiness, validation results, PR readiness, merge readiness and ordinary
 - Treat access or capability as distinct from permission.
 - Prefer the minimum safe change and fail closed when decision-critical evidence is missing.
 - Do not ask for routine `proceed` confirmations when existing authority and evidence already determine the safe action.
-- A fresh review disposition does not itself create mutation authority. After the review, continue through autonomous progression only when the governing task already permits that continuation and independence is no longer at risk.
+- A fresh review disposition does not itself create mutation authority. When fresh review is an intermediate gate under this router, record its single clear disposition and concise rationale, then continue through autonomous progression only when the governing task already permits that continuation and independence is no longer at risk; the review result alone is not a terminal state.
 - A requested handover is terminal for the current deliverable; execution belongs to the receiving context.
 - Do not invent adjacent work after the governed objective is complete.
 

--- a/prompts/workflows/README.md
+++ b/prompts/workflows/README.md
@@ -1,0 +1,78 @@
+# Workflow router
+
+This directory is the canonical Promptbook entry point for governed engineering workflow continuation.
+
+Point the agent here when you want it to determine the appropriate reusable workflow from the current task state rather than choosing an individual prompt yourself. The router does not grant authority: platform safety rules, explicit task authority, repository-local instructions and current authoritative evidence remain higher precedence.
+
+## Using the router
+
+For ordinary continuation:
+
+```text
+Use `8ft0-ai/promptbook` → `prompts/workflows/README.md` as the workflow entry point.
+Reconstruct the material current state and continue the governed work with minimal human intervention.
+```
+
+For a bounded approval:
+
+```text
+Follow `8ft0-ai/promptbook` → `prompts/workflows/README.md`.
+Approved — proceed.
+```
+
+Do not manually choose a workflow when this router can determine the route from current evidence.
+
+## Routing
+
+Before routing, inspect the current conversation and the authoritative repository or task state needed for the next decision. Stale summaries are navigation aids, not authority. Select exactly one primary workflow and apply it immediately; routing itself is not a stop point.
+
+Use the first matching case:
+
+1. **A handover or next-session prompt is explicitly the requested deliverable** → [Next-session handover](next-session-handover.md).
+   - Produce the handover only. Do not reinterpret a request for a prompt as authority to execute the handed-off task in the current context.
+
+2. **The current context is genuinely fresh and an independent substantive review is required now** → [Fresh independent review](fresh-independent-review.md).
+   - Reconstruct the decision from the actual candidate and evidence rather than inheriting the authoring conclusion.
+   - If independence is required but the current context is not genuinely fresh, use the handover workflow to produce a complete fresh-context review handoff and stop as `EXTERNAL_REQUIRED`.
+
+3. **A newly supplied bounded approval or execution authority applies to the current proposal or action** → [Autonomous progression](autonomous-progression.md).
+   - Identify the exact proposal or action being authorised.
+   - Refresh decision-critical state and verify that the proposal/action and its authority boundary remain materially unchanged.
+   - Consume the approval or authority once, only for that bounded object, then continue routine governed work through autonomous progression.
+   - Do not treat approval as authority to expand scope, weaken controls or accept a materially changed proposal. Escalate a genuinely new human choice as `DECISION_REQUIRED`.
+
+4. **Ordinary governed continuation** → [Autonomous progression](autonomous-progression.md).
+   - Continue while current policy, evidence, scope and available capabilities safely determine the next action.
+
+5. **No safe route fits** → fail closed.
+   - Do not invent work, authority or a workflow mapping merely to keep moving.
+   - Use the terminal-state rules below to identify the real boundary.
+
+## Terminal states
+
+A workflow should stop only as one of these states:
+
+- `EXTERNAL_REQUIRED` — the next required action cannot legitimately be performed in the current environment, but a complete executable handoff can resolve it.
+- `DECISION_REQUIRED` — a genuine human judgement or authority decision is required.
+- `BLOCKED` — no safe autonomous action, executable external handoff or concrete human decision can resolve the condition now.
+- `COMPLETE` — the governed objective is genuinely finished, including required verification and close-out.
+
+Review readiness, validation results, PR readiness, merge readiness and ordinary next actions are not terminal states by themselves.
+
+## Selection and continuation rules
+
+- Select one primary workflow rather than concatenating the prompt set.
+- Refresh material current state before consequential actions.
+- Preserve repository-local authority, validation requirements, security boundaries and explicit task constraints.
+- Treat access or capability as distinct from permission.
+- Prefer the minimum safe change and fail closed when decision-critical evidence is missing.
+- Do not ask for routine `proceed` confirmations when existing authority and evidence already determine the safe action.
+- A fresh review disposition does not itself create mutation authority. After the review, continue through autonomous progression only when the governing task already permits that continuation and independence is no longer at risk.
+- A requested handover is terminal for the current deliverable; execution belongs to the receiving context.
+- Do not invent adjacent work after the governed objective is complete.
+
+## Current workflows
+
+- [Autonomous progression](autonomous-progression.md) — continue already-governed work with minimal human orchestration.
+- [Fresh independent review](fresh-independent-review.md) — reconstruct and adjudicate a candidate from a genuinely fresh context.
+- [Next-session handover](next-session-handover.md) — create the shortest safe continuation prompt for another context or capability boundary.

--- a/tests/test_validate_promptbook.py
+++ b/tests/test_validate_promptbook.py
@@ -50,6 +50,32 @@ class PromptbookValidationTests(unittest.TestCase):
             errors = MODULE.validate_text_safety(path, "source: ai-prompt-library")
             self.assertTrue(errors)
 
+    def test_workflow_router_contract(self):
+        text = (ROOT / "prompts" / "workflows" / "README.md").read_text(encoding="utf-8")
+
+        for target in (
+            "autonomous-progression.md",
+            "fresh-independent-review.md",
+            "next-session-handover.md",
+        ):
+            self.assertIn(target, text)
+
+        for terminal_state in (
+            "EXTERNAL_REQUIRED",
+            "DECISION_REQUIRED",
+            "BLOCKED",
+            "COMPLETE",
+        ):
+            self.assertIn(terminal_state, text)
+
+        self.assertIn("fresh", text.lower())
+        self.assertIn("handover", text.lower())
+        self.assertIn("approval", text.lower())
+        self.assertIn("execution authority", text.lower())
+
+        for pattern in MODULE.PRIVATE_PATTERNS.values():
+            self.assertNotIn(pattern, text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_validate_promptbook.py
+++ b/tests/test_validate_promptbook.py
@@ -69,6 +69,7 @@ class PromptbookValidationTests(unittest.TestCase):
             self.assertIn(terminal_state, text)
 
         self.assertIn("fresh", text.lower())
+        self.assertIn("not genuinely fresh", text.lower())
         self.assertIn("handover", text.lower())
         self.assertIn("approval", text.lower())
         self.assertIn("execution authority", text.lower())


### PR DESCRIPTION
Closes #3.

Adds a single public workflow entrypoint that routes governed continuation to the existing autonomous progression, fresh independent review, or next-session handover prompts while preserving repository-local authority and fail-closed terminal states.

Exact intended scope:
- add `prompts/workflows/README.md`;
- update root `README.md`;
- update `prompts/README.md`;
- update `tests/test_validate_promptbook.py` with router regression coverage.

No existing workflow prompt body, maturity status, unrelated prompt, automation contract, or consumer repository is changed.

Validation will be bound to the exact PR head through the repository's existing CI (`python scripts/validate_promptbook.py` and `python -m unittest discover -s tests -p 'test_*.py' -v`). Local network access was unavailable in the authoring environment, so CI is the executable validation environment rather than an unverified claim of local execution.