### PR TITLE
Fix fresh review continuation under workflow router

### DIFF
--- a/prompts/workflows/README.md
+++ b/prompts/workflows/README.md
@@ -67,7 +67,8 @@ Review readiness, validation results, PR readiness, merge readiness and ordinary
 - Treat access or capability as distinct from permission.
 - Prefer the minimum safe change and fail closed when decision-critical evidence is missing.
 - Do not ask for routine `proceed` confirmations when existing authority and evidence already determine the safe action.
-- A fresh review disposition does not itself create mutation authority. When fresh review is an intermediate gate under this router, record its single clear disposition and concise rationale, then continue through autonomous progression only when the governing task already permits that continuation and independence is no longer at risk; the review result alone is not a terminal state.
+- Output or deliverable constraints inside a selected workflow apply to that workflow's record. They do not override this router's continuation semantics unless the user or governing task explicitly requested that workflow result as the final deliverable.
+- A fresh review disposition does not itself create mutation authority. When fresh review is an intermediate gate under this router, record its single clear disposition and concise rationale, then return control to the governing workflow. If `CHANGES REQUIRED` identifies a bounded defect whose minimum-safe remediation is objectively determined and already authorised, continue through autonomous progression to remediate and validate it without another routine approval. Because that context then authored the changed candidate, route the new candidate to a genuinely fresh review context before any gate requiring independence. If the disposition is `APPROVED`, continue already-authorised merge, verification and close-out work rather than stopping at review completion.
 - A requested handover is terminal for the current deliverable; execution belongs to the receiving context.
 - Do not invent adjacent work after the governed objective is complete.
 

--- a/prompts/workflows/fresh-independent-review.md
+++ b/prompts/workflows/fresh-independent-review.md
@@ -20,6 +20,12 @@ Reach the substantive conclusion from freshly inspected evidence. Do not inherit
 If expected state changed, determine what changed and whether the review remains safely decidable; do not fail mechanically merely because an identity moved when the governing contract permits reconciliation.
 
 Return exactly one clear disposition appropriate to the gate (for example APPROVED / CHANGES REQUIRED), followed by concise decisive rationale. For a negative disposition, identify only material blockers that must be resolved.
+
+That single disposition is the review record. If this review was explicitly requested as the final deliverable, stop after recording it. If a governing workflow or router invoked this review as an intermediate gate, return control to that workflow after recording the disposition; do not treat review completion itself as a terminal state.
+
+A review result never creates mutation authority. If CHANGES REQUIRED identifies a bounded defect whose minimum-safe remediation is objectively determined and already authorised by the governing task, the governing workflow may perform and validate that remediation without another routine approval. Once this context authors or materially shapes the changed candidate, it must not claim a fresh independent review of that changed candidate; route it to a genuinely fresh review context before any gate that requires independence.
+
+If the disposition is APPROVED, the governing workflow may continue any already-authorised merge, verification, and close-out work. Do not stop merely because the review gate completed when the overall governed task still has authorised, safely decidable work remaining.
 ```
 
 ## Inputs
@@ -29,11 +35,11 @@ Return exactly one clear disposition appropriate to the gate (for example APPROV
 
 ## What it does
 
-Creates an information boundary between authoring and adjudication and forces the reviewer to inspect the real evidence rather than merely validating a handover summary.
+Creates an information boundary between authoring and adjudication and forces the reviewer to inspect the real evidence rather than merely validating a handover summary. When composed inside a governing workflow, it records the independent disposition without turning review completion into an unnecessary conversational stop.
 
 ## Boundaries / limitations
 
-Freshness is a property of prior information, not a prompt incantation. A context that substantially authored the candidate or already saw the expected answer cannot become independent merely by being told to forget it.
+Freshness is a property of prior information, not a prompt incantation. A context that substantially authored the candidate or already saw the expected answer cannot become independent merely by being told to forget it. The review result does not grant mutation authority; any remediation or continuation must already be authorised by the governing task or workflow.
 
 ## Status
 

--- a/tests/test_validate_promptbook.py
+++ b/tests/test_validate_promptbook.py
@@ -73,6 +73,27 @@ class PromptbookValidationTests(unittest.TestCase):
         self.assertIn("handover", text.lower())
         self.assertIn("approval", text.lower())
         self.assertIn("execution authority", text.lower())
+        self.assertIn("return control to the governing workflow", text.lower())
+        self.assertIn("minimum-safe remediation", text.lower())
+        self.assertIn("final deliverable", text.lower())
+        self.assertIn("does not itself create mutation authority", text.lower())
+
+        for pattern in MODULE.PRIVATE_PATTERNS.values():
+            self.assertNotIn(pattern, text)
+
+    def test_fresh_review_composition_contract(self):
+        text = (
+            ROOT / "prompts" / "workflows" / "fresh-independent-review.md"
+        ).read_text(encoding="utf-8")
+        lower = text.lower()
+
+        self.assertIn("single disposition is the review record", lower)
+        self.assertIn("explicitly requested as the final deliverable", lower)
+        self.assertIn("return control to that workflow", lower)
+        self.assertIn("minimum-safe remediation", lower)
+        self.assertIn("review result never creates mutation authority", lower)
+        self.assertIn("must not claim a fresh independent review", lower)
+        self.assertIn("already-authorised merge, verification, and close-out", lower)
 
         for pattern in MODULE.PRIVATE_PATTERNS.values():
             self.assertNotIn(pattern, text)


### PR DESCRIPTION
Closes #5.

Fixes the composition ambiguity that allowed a routed fresh review to stop after `CHANGES REQUIRED` even when a bounded, objectively determined remediation was already authorised.

Exact scope:
- clarify `prompts/workflows/fresh-independent-review.md` so its single disposition is the review record, while standalone review requests still stop there;
- clarify `prompts/workflows/README.md` so routed intermediate reviews return control to the governing workflow, permit already-authorised minimum-safe remediation, preserve fresh-review independence for the changed candidate, and continue already-authorised post-approval work;
- add regression assertions in `tests/test_validate_promptbook.py` for both continuation and standalone-final-deliverable semantics.

This does not grant mutation authority from a review result, weaken independence, change terminal states, or alter unrelated prompts.

Base: `main@496e21acfbb325eb66ac1d01ec40a3d12a0cd0d3`.
Candidate head at PR creation: `d5ed47821207e53c6e549cabf6a35783b139095e`.

Repository CI is the executable validation gate. This authoring context will not claim an independent substantive review of its own candidate.