### PR TITLE
Add project bootstrap and shorthand commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Promptbook is for engineers and technical practitioners who want AI assistants t
 | Turn an issue into an implementation plan | [Plan an issue](prompts/engineering/plan-an-issue.md) |
 | Review a pull request substantively | [Review a pull request](prompts/engineering/pr-review.md) |
 | Continue governed work or determine the next workflow | [Workflow router](prompts/workflows/README.md) |
+| Set up recurring project-chat invocation | [Project bootstrap and shorthand commands](guides/project-bootstrap.md) |
 | Re-review work from a fresh context | [Fresh independent review](prompts/workflows/fresh-independent-review.md) |
 
 Browse the complete collection in [`prompts/`](prompts/README.md).
@@ -22,6 +23,8 @@ Browse the complete collection in [`prompts/`](prompts/README.md).
 3. Replace the declared `<PLACEHOLDERS>` with your actual context where applicable.
 4. Give the prompt to the AI assistant or agent that has the capabilities needed for the task.
 5. Keep repository-local instructions, platform safety rules, and explicit task authority above generic Promptbook guidance.
+
+For repeated use across project chat sessions, use the [project bootstrap pattern](guides/project-bootstrap.md) so persistent project instructions stay thin while repository-local instructions own the Promptbook version/pin and the workflow router owns shorthand command behaviour.
 
 See [Using Promptbook](guides/using-promptbook.md) for copy, adaptation, and composition patterns.
 
@@ -44,6 +47,7 @@ Status describes the evidence behind the Promptbook prompt. It is not a claim of
 ## Guides
 
 - [Using Promptbook](guides/using-promptbook.md)
+- [Project bootstrap and shorthand commands](guides/project-bootstrap.md)
 - [Adapting prompts](guides/adapting-prompts.md)
 - [Design principles](guides/design-principles.md)
 

--- a/guides/project-bootstrap.md
+++ b/guides/project-bootstrap.md
@@ -1,0 +1,79 @@
+# Project bootstrap and shorthand commands
+
+Use this pattern when a project or repository should use Promptbook repeatedly across chat sessions without copying Promptbook prompt bodies into local instructions.
+
+The intended layering is:
+
+```text
+project/workspace bootstrap
+        ↓
+repository-local authority
+        ↓
+Promptbook workflow router and task prompts
+```
+
+The bootstrap tells the agent where to start. Repository instructions remain authoritative for local scope and policy. Promptbook owns reusable workflow behaviour and shorthand semantics.
+
+## Project bootstrap
+
+Keep persistent project or workspace instructions thin. A suitable bootstrap is:
+
+```text
+For governed engineering work, first read and apply repository-local instructions, including AGENTS.md when present.
+
+Unless repository-local instructions specify another supported workflow, use `8ft0-ai/promptbook` → `prompts/workflows/README.md` as the governed-workflow entry point, using any Promptbook version/ref declared by the repository.
+
+Reconstruct decision-critical current state from authoritative sources rather than stale conversation summaries. Preserve platform safety constraints, explicit task authority, repository-local policy, validation requirements and current evidence above Promptbook guidance.
+
+Continue with minimal unnecessary human intervention. Interpret Promptbook shorthand commands according to the workflow router. The bootstrap and commands select workflow intent only: they do not grant additional authority or bypass freshness, independence, validation or fail-closed behaviour.
+```
+
+This text deliberately does not duplicate lifecycle procedures or individual prompt bodies. Those remain versioned in Promptbook.
+
+## Repository declaration
+
+For reproducible use, declare the Promptbook dependency in repository-local instructions. For example, an `AGENTS.md` can include:
+
+```md
+## Promptbook
+
+This repository uses `8ft0-ai/promptbook@vX.Y.Z` for reusable governed-workflow guidance.
+
+Workflow entry point: `prompts/workflows/README.md`.
+
+Repository-local instructions, explicit task authority, security policy and validation requirements take precedence over Promptbook. Promptbook and its shorthand commands do not grant additional authority.
+
+Use the shorthand commands defined by the pinned Promptbook workflow router; do not copy their implementation into this repository.
+```
+
+Pinning a stable release makes the workflow dependency reproducible and reviewable. A repository may deliberately track `main` instead, but that opts into behaviour changes as Promptbook evolves. Keep the project-level bootstrap version-neutral and let the repository own the pin or override.
+
+## Shorthand commands
+
+The canonical command semantics live in [`prompts/workflows/README.md`](../prompts/workflows/README.md). The small public vocabulary is:
+
+- `/go [target]` — continue the governed objective through the router; when the target is already clear, `/go` alone means perform the next authorised, safely decidable action rather than merely describe the next gate.
+- `/review [target]` — request a substantive fresh review as the current deliverable, preserving the fresh-context boundary.
+- `/plan [target]` — plan bounded work using the Promptbook planning prompt.
+- `/implement [target]` — implement already-approved bounded work using the Promptbook implementation prompt.
+- `/fix [target]` — remediate current bounded review findings using existing authority.
+- `/handoff [target]` — produce the shortest safe continuation handoff without executing the handed-off task.
+- `/status [target]` — reconstruct and report authoritative current state read-only; do not mutate unless the user separately requests continuation.
+
+Commands are intentionally not a mini CLI. Add natural-language qualifiers when needed, for example:
+
+```text
+/go until the next genuinely fresh review boundary
+/status issue #42
+/review PR #17
+```
+
+If the target is omitted, resolve it from the current conversation and authoritative repository state. If that is not safely possible, fail closed rather than guessing.
+
+## Direct prompt escape hatch
+
+The router is the default for ordinary continuation. A caller may still explicitly name an individual Promptbook prompt when that exact standalone deliverable is wanted. Explicit prompt selection does not weaken repository-local precedence or create authority that the task does not already have.
+
+## Updating the dependency
+
+When a repository pins a Promptbook release, update the pin through an ordinary reviewed repository change. This keeps Promptbook functioning like a workflow dependency rather than copied configuration. The consumer repository should not need to change merely because Promptbook adds unrelated prompts; update when the newer Promptbook contract is intentionally adopted.

--- a/guides/project-bootstrap.md
+++ b/guides/project-bootstrap.md
@@ -25,7 +25,7 @@ Unless repository-local instructions specify another supported workflow, use `8f
 
 Reconstruct decision-critical current state from authoritative sources rather than stale conversation summaries. Preserve platform safety constraints, explicit task authority, repository-local policy, validation requirements and current evidence above Promptbook guidance.
 
-Continue with minimal unnecessary human intervention. Interpret Promptbook shorthand commands according to the workflow router. The bootstrap and commands select workflow intent only: they do not grant additional authority or bypass freshness, independence, validation or fail-closed behaviour.
+Continue with minimal unnecessary human intervention until `EXTERNAL_REQUIRED`, `DECISION_REQUIRED`, `BLOCKED`, or `COMPLETE` applies. Interpret Promptbook shorthand commands according to the workflow router. The bootstrap and commands select workflow intent only: they do not grant additional authority or bypass freshness, independence, validation or fail-closed behaviour.
 ```
 
 This text deliberately does not duplicate lifecycle procedures or individual prompt bodies. Those remain versioned in Promptbook.

--- a/guides/using-promptbook.md
+++ b/guides/using-promptbook.md
@@ -1,6 +1,6 @@
 # Using Promptbook
 
-Promptbook supports three simple usage modes: copy, adapt, and compose.
+Promptbook supports four simple usage modes: copy, adapt, compose, and bootstrap.
 
 ## Copy and use
 
@@ -27,3 +27,9 @@ When guidance conflicts, apply this precedence:
 5. generic Promptbook guidance.
 
 If the conflict changes what is authorised or materially changes the intended outcome, resolve it explicitly rather than silently choosing the most convenient instruction.
+
+## Bootstrap repeated project use
+
+For project chats or other persistent workspaces, do not copy Promptbook prompt bodies into project instructions. Use a thin bootstrap that points the agent at repository-local instructions and the Promptbook workflow router, and let the repository declare any Promptbook version/pin. The router owns the public shorthand command vocabulary such as `/go`, `/review`, `/fix`, and `/status`.
+
+See [Project bootstrap and shorthand commands](project-bootstrap.md) for copyable bootstrap text, an `AGENTS.md` declaration pattern, command semantics, and versioning guidance.

--- a/prompts/workflows/README.md
+++ b/prompts/workflows/README.md
@@ -22,6 +22,20 @@ Approved — proceed.
 
 Do not manually choose a workflow when this router can determine the route from current evidence.
 
+## Shorthand commands
+
+When a user message begins with one of these commands, treat it as a concise intent selector. Resolve an omitted target from the current conversation and authoritative repository/task state only when that is unambiguous. Commands do not grant authority, bypass repository policy, weaken freshness or independence requirements, or turn unavailable capabilities into available ones.
+
+- `/go [target]` — continue the governed objective through this router. If the target is already established, `/go` alone means perform the next authorised, safely decidable action rather than merely describing the next gate or asking for a routine `proceed` confirmation. Natural-language qualifiers such as `/go until the next genuinely fresh review boundary` are allowed.
+- `/review [target]` — request a substantive independent review using [Fresh independent review](fresh-independent-review.md). Treat the review disposition as the requested final deliverable unless the user explicitly asks to continue afterwards. If the current context is not genuinely fresh for the required decision, use [Next-session handover](next-session-handover.md) and stop as `EXTERNAL_REQUIRED` rather than substituting author-side reasoning.
+- `/plan [target]` — use [Plan an issue](../engineering/plan-an-issue.md). Planning remains non-implementation work unless separate authority says otherwise.
+- `/implement [target]` — use [Implement an approved issue](../engineering/implement-an-approved-issue.md). The target must already be sufficiently approved/determined and repository mutation must already be authorised.
+- `/fix [target]` — use [Remediate review findings](../engineering/remediate-review-findings.md) for objectively bounded findings under existing authority. Preserve any required fresh re-review boundary after changing the candidate.
+- `/handoff [target]` — use [Next-session handover](next-session-handover.md). The handoff is the final deliverable; do not execute the handed-off task in the current context.
+- `/status [target]` — reconstruct decision-critical current state and report concise authoritative status read-only. Do not mutate, merge, dispatch, or otherwise continue the governed task unless the user separately requests continuation.
+
+Keep the command set small. Prefer natural-language qualifiers over inventing flags or a larger command grammar.
+
 ## Routing
 
 Before routing, inspect the current conversation and the authoritative repository or task state needed for the next decision. Stale summaries are navigation aids, not authority. Select exactly one primary workflow and apply it immediately; routing itself is not a stop point.

--- a/tests/test_validate_promptbook.py
+++ b/tests/test_validate_promptbook.py
@@ -52,11 +52,15 @@ class PromptbookValidationTests(unittest.TestCase):
 
     def test_workflow_router_contract(self):
         text = (ROOT / "prompts" / "workflows" / "README.md").read_text(encoding="utf-8")
+        lower = text.lower()
 
         for target in (
             "autonomous-progression.md",
             "fresh-independent-review.md",
             "next-session-handover.md",
+            "../engineering/plan-an-issue.md",
+            "../engineering/implement-an-approved-issue.md",
+            "../engineering/remediate-review-findings.md",
         ):
             self.assertIn(target, text)
 
@@ -68,15 +72,29 @@ class PromptbookValidationTests(unittest.TestCase):
         ):
             self.assertIn(terminal_state, text)
 
-        self.assertIn("fresh", text.lower())
-        self.assertIn("not genuinely fresh", text.lower())
-        self.assertIn("handover", text.lower())
-        self.assertIn("approval", text.lower())
-        self.assertIn("execution authority", text.lower())
-        self.assertIn("return control to the governing workflow", text.lower())
-        self.assertIn("minimum-safe remediation", text.lower())
-        self.assertIn("final deliverable", text.lower())
-        self.assertIn("does not itself create mutation authority", text.lower())
+        for command in (
+            "/go",
+            "/review",
+            "/plan",
+            "/implement",
+            "/fix",
+            "/handoff",
+            "/status",
+        ):
+            self.assertIn(command, text)
+
+        self.assertIn("fresh", lower)
+        self.assertIn("not genuinely fresh", lower)
+        self.assertIn("handover", lower)
+        self.assertIn("approval", lower)
+        self.assertIn("execution authority", lower)
+        self.assertIn("return control to the governing workflow", lower)
+        self.assertIn("minimum-safe remediation", lower)
+        self.assertIn("final deliverable", lower)
+        self.assertIn("does not itself create mutation authority", lower)
+        self.assertIn("commands do not grant authority", lower)
+        self.assertIn("read-only", lower)
+        self.assertIn("routine `proceed` confirmation", lower)
 
         for pattern in MODULE.PRIVATE_PATTERNS.values():
             self.assertNotIn(pattern, text)
@@ -94,6 +112,46 @@ class PromptbookValidationTests(unittest.TestCase):
         self.assertIn("review result never creates mutation authority", lower)
         self.assertIn("must not claim a fresh independent review", lower)
         self.assertIn("already-authorised merge, verification, and close-out", lower)
+
+        for pattern in MODULE.PRIVATE_PATTERNS.values():
+            self.assertNotIn(pattern, text)
+
+    def test_project_bootstrap_contract(self):
+        path = ROOT / "guides" / "project-bootstrap.md"
+        text = path.read_text(encoding="utf-8")
+        lower = text.lower()
+
+        self.assertIn("AGENTS.md", text)
+        self.assertIn("prompts/workflows/README.md", text)
+        self.assertIn("8ft0-ai/promptbook@vX.Y.Z", text)
+        self.assertIn("stable release", lower)
+        self.assertIn("track `main`", lower)
+        self.assertIn("do not grant additional authority", lower)
+        self.assertIn("read-only", lower)
+
+        for terminal_state in (
+            "EXTERNAL_REQUIRED",
+            "DECISION_REQUIRED",
+            "BLOCKED",
+            "COMPLETE",
+        ):
+            self.assertIn(terminal_state, text)
+
+        for command in (
+            "/go",
+            "/review",
+            "/plan",
+            "/implement",
+            "/fix",
+            "/handoff",
+            "/status",
+        ):
+            self.assertIn(command, text)
+
+        readme = (ROOT / "README.md").read_text(encoding="utf-8")
+        using = (ROOT / "guides" / "using-promptbook.md").read_text(encoding="utf-8")
+        self.assertIn("guides/project-bootstrap.md", readme)
+        self.assertIn("project-bootstrap.md", using)
 
         for pattern in MODULE.PRIVATE_PATTERNS.values():
             self.assertNotIn(pattern, text)


### PR DESCRIPTION
Closes #7.

Adds the minimum reusable invocation layer for using Promptbook across project chat sessions without copying prompt bodies into consumer repositories.

Exact scope:
- add `guides/project-bootstrap.md` with a thin persistent project/workspace bootstrap and repository `AGENTS.md` declaration pattern;
- add canonical shorthand semantics to `prompts/workflows/README.md` for `/go`, `/review`, `/plan`, `/implement`, `/fix`, `/handoff`, and `/status`;
- document the bootstrap usage mode in `README.md` and `guides/using-promptbook.md`;
- add regression coverage in `tests/test_validate_promptbook.py` for command mapping, read-only status, fresh-review handling, authority preservation, terminal states, repository-owned version pinning, and discoverability.

Design choices:
- `/go` remains router-driven autonomous continuation;
- task-specific commands select existing Promptbook behaviours rather than introducing a new command engine;
- `/review`, `/handoff`, and `/status` have explicit final-deliverable/read-only semantics;
- commands are intent selectors only and never grant mutation authority;
- persistent project instructions stay version-neutral; repositories may pin a stable Promptbook release in local instructions for reproducibility;
- direct individual-prompt invocation remains supported.

Required/current base at authoring: `main@fd7a6f01829f021467f0aa9105467727c6793cee`.
Candidate head at PR creation: `dac7a284e4cc48cc6e321222d6159ae9869bb72b`.

Repository CI is the executable validation gate. This authoring context will not claim an independent substantive review of its own candidate.