### PR TITLE
Add AGENTS.md and enforce command documentation consistency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# Agent instructions
+
+## Repository purpose
+
+Promptbook is a curated public collection of reusable prompts and workflows for disciplined, evidence-driven agentic engineering. Keep changes public-safe, model-portable, task-oriented, and smaller than the private or project-specific histories from which reusable patterns may have emerged.
+
+Do not publish credentials, private identifiers, hidden provenance, organisation-specific assumptions, or internal history that is not required to use the public prompt or workflow.
+
+## Governing workflow
+
+Before mutating the repository, inspect the current issue or task, repository state, relevant discussion, and validation requirements. Repository-local instructions and explicit task authority take precedence over reusable Promptbook guidance.
+
+For governed continuation, use [`prompts/workflows/README.md`](prompts/workflows/README.md) as the workflow entry point. Continue routine authorised work without unnecessary human confirmation, but do not invent mutation, merge, release, credential, scope, or production authority.
+
+Preserve genuine fresh-review boundaries. A context that authored or materially shaped a candidate must not present its own review as fresh independent evidence when independence is required.
+
+Prefer the minimum safe change. Do not broaden a bounded issue with unrelated cleanup, taxonomy changes, new commands, or maturity changes unless separately authorised.
+
+## Validation
+
+Run the repository validation required by CI for every public-interface change. Do not weaken tests, assertions, public-safety checks, link validation, or command/bootstrap drift checks merely to make a candidate pass.
+
+When behaviour changes, add or update regression coverage that would fail if the intended contract regressed.
+
+## Public interface maintenance
+
+The current public shorthand vocabulary is:
+
+`/go`, `/review`, `/plan`, `/implement`, `/fix`, `/handoff`, `/status`.
+
+`prompts/workflows/README.md` is canonical for command semantics. The root `README.md` is the quick-start/discovery surface, `guides/project-bootstrap.md` is the setup surface, and `BOOTSTRAP` is the copyable project-bootstrap text.
+
+When the shorthand vocabulary or bootstrap contract changes, update all affected public surfaces in the same change and update regression coverage so CI fails on accidental drift. Keep the command set aligned across the router, README, bootstrap guide, and this maintenance declaration. Keep `BOOTSTRAP` aligned with the copyable project-bootstrap block in the guide.
+
+Do not copy full Promptbook prompt bodies into this file, README, or consumer-repository instructions. Link to the canonical prompt or workflow instead.
+
+## Delivery discipline
+
+Keep issue-to-change traceability explicit. Before merge, inspect the complete diff, verify scope against the governing issue, ensure required checks pass on the exact candidate, and confirm no unresolved blocking review state remains.
+
+After merge, verify the resulting `main` state and required post-merge validation before closing the governed objective.

--- a/BOOTSTRAP
+++ b/BOOTSTRAP
@@ -4,4 +4,4 @@ Unless repository-local instructions specify another supported workflow, use `8f
 
 Reconstruct decision-critical current state from authoritative sources rather than stale conversation summaries. Preserve platform safety constraints, explicit task authority, repository-local policy, validation requirements and current evidence above Promptbook guidance.
 
-Continue with minimal unnecessary human intervention until EXTERNAL_REQUIRED, DECISION_REQUIRED, BLOCKED, or COMPLETE applies. Interpret Promptbook shorthand commands according to the workflow router.
+Continue with minimal unnecessary human intervention until `EXTERNAL_REQUIRED`, `DECISION_REQUIRED`, `BLOCKED`, or `COMPLETE` applies. Interpret Promptbook shorthand commands according to the workflow router. The bootstrap and commands select workflow intent only: they do not grant additional authority or bypass freshness, independence, validation or fail-closed behaviour.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,31 @@ Promptbook is for engineers and technical practitioners who want AI assistants t
 
 Browse the complete collection in [`prompts/`](prompts/README.md).
 
+## Quick commands
+
+Once Promptbook is configured for a project, common workflow intents can be invoked with:
+
+| Command | Intent |
+| --- | --- |
+| `/go [target]` | Continue governed work as far as safely possible |
+| `/review [target]` | Request a substantive independent review |
+| `/plan [target]` | Plan bounded work |
+| `/implement [target]` | Implement already-approved bounded work |
+| `/fix [target]` | Remediate bounded review findings |
+| `/handoff [target]` | Produce a continuation handoff without executing it |
+| `/status [target]` | Reconstruct and report authoritative current state, read-only |
+
+Examples:
+
+```text
+/go issue #42
+/review PR #43
+/fix
+/status
+```
+
+Commands are shorthand intent selectors only. They do not grant authority or bypass repository-local instructions, validation, security controls, freshness, or independent-review requirements. See [Project bootstrap and shorthand commands](guides/project-bootstrap.md) for setup and the [Workflow router](prompts/workflows/README.md) for canonical command semantics.
+
 ## How to use Promptbook
 
 1. Open a prompt that matches the task you want to perform, or start from the [workflow router](prompts/workflows/README.md) when the next governed workflow should be selected from current state.

--- a/scripts/validate_promptbook.py
+++ b/scripts/validate_promptbook.py
@@ -10,7 +10,14 @@ from urllib.parse import unquote
 
 ROOT = Path(__file__).resolve().parents[1]
 PROMPTS = ROOT / "prompts"
-REQUIRED_ROOT = ["README.md", "CONTRIBUTING.md", "LICENSE", "templates/prompt-template.md"]
+REQUIRED_ROOT = [
+    "README.md",
+    "AGENTS.md",
+    "BOOTSTRAP",
+    "CONTRIBUTING.md",
+    "LICENSE",
+    "templates/prompt-template.md",
+]
 REQUIRED_HEADINGS = [
     "Purpose",
     "When to use",
@@ -115,7 +122,12 @@ def validate_repository(root: Path = ROOT) -> list[str]:
     for path in prompt_files:
         errors.extend(validate_prompt_file(path))
 
-    for path in sorted(root.rglob("*.md")):
+    public_text_paths = set(root.rglob("*.md"))
+    bootstrap = root / "BOOTSTRAP"
+    if bootstrap.exists():
+        public_text_paths.add(bootstrap)
+
+    for path in sorted(public_text_paths):
         text = path.read_text(encoding="utf-8")
         errors.extend(validate_text_safety(path, text))
         errors.extend(validate_links(path, text, root))

--- a/tests/test_validate_promptbook.py
+++ b/tests/test_validate_promptbook.py
@@ -1,4 +1,5 @@
 import importlib.util
+import re
 import tempfile
 import unittest
 from pathlib import Path
@@ -10,6 +11,24 @@ SPEC = importlib.util.spec_from_file_location(
 MODULE = importlib.util.module_from_spec(SPEC)
 assert SPEC.loader is not None
 SPEC.loader.exec_module(MODULE)
+
+PUBLIC_COMMANDS = {
+    "/go",
+    "/review",
+    "/plan",
+    "/implement",
+    "/fix",
+    "/handoff",
+    "/status",
+}
+COMMAND_RE = re.compile(r"`(/[-a-z]+)(?:\s[^`]*)?`")
+
+
+def declared_commands(text: str, heading: str) -> set[str]:
+    return {
+        match.group(1)
+        for match in COMMAND_RE.finditer(MODULE.section(text, heading))
+    }
 
 
 class PromptbookValidationTests(unittest.TestCase):
@@ -72,16 +91,7 @@ class PromptbookValidationTests(unittest.TestCase):
         ):
             self.assertIn(terminal_state, text)
 
-        for command in (
-            "/go",
-            "/review",
-            "/plan",
-            "/implement",
-            "/fix",
-            "/handoff",
-            "/status",
-        ):
-            self.assertIn(command, text)
+        self.assertEqual(PUBLIC_COMMANDS, declared_commands(text, "Shorthand commands"))
 
         self.assertIn("fresh", lower)
         self.assertIn("not genuinely fresh", lower)
@@ -137,16 +147,7 @@ class PromptbookValidationTests(unittest.TestCase):
         ):
             self.assertIn(terminal_state, text)
 
-        for command in (
-            "/go",
-            "/review",
-            "/plan",
-            "/implement",
-            "/fix",
-            "/handoff",
-            "/status",
-        ):
-            self.assertIn(command, text)
+        self.assertEqual(PUBLIC_COMMANDS, declared_commands(text, "Shorthand commands"))
 
         readme = (ROOT / "README.md").read_text(encoding="utf-8")
         using = (ROOT / "guides" / "using-promptbook.md").read_text(encoding="utf-8")
@@ -155,6 +156,44 @@ class PromptbookValidationTests(unittest.TestCase):
 
         for pattern in MODULE.PRIVATE_PATTERNS.values():
             self.assertNotIn(pattern, text)
+
+    def test_public_command_docs_stay_aligned(self):
+        surfaces = (
+            (ROOT / "README.md", "Quick commands"),
+            (ROOT / "guides" / "project-bootstrap.md", "Shorthand commands"),
+            (ROOT / "prompts" / "workflows" / "README.md", "Shorthand commands"),
+            (ROOT / "AGENTS.md", "Public interface maintenance"),
+        )
+
+        for path, heading in surfaces:
+            text = path.read_text(encoding="utf-8")
+            self.assertEqual(
+                PUBLIC_COMMANDS,
+                declared_commands(text, heading),
+                f"public command vocabulary drifted in {path}",
+            )
+
+    def test_bootstrap_copy_stays_aligned_with_guide(self):
+        bootstrap = (ROOT / "BOOTSTRAP").read_text(encoding="utf-8").strip()
+        guide = (ROOT / "guides" / "project-bootstrap.md").read_text(encoding="utf-8")
+
+        self.assertIn(
+            f"```text\n{bootstrap}\n```",
+            guide,
+            "BOOTSTRAP must match the copyable project bootstrap block in the guide",
+        )
+
+    def test_agents_declares_public_interface_maintenance(self):
+        text = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+        lower = text.lower()
+
+        self.assertIn("prompts/workflows/README.md", text)
+        self.assertIn("README.md", text)
+        self.assertIn("guides/project-bootstrap.md", text)
+        self.assertIn("BOOTSTRAP", text)
+        self.assertIn("regression coverage", lower)
+        self.assertIn("ci fails on accidental drift", lower)
+        self.assertIn("fresh-review", lower)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #9.

Adds Promptbook's repository-local agent instructions and makes the public shorthand command interface both discoverable and mechanically maintained.

Exact scope:
- add root `AGENTS.md` with Promptbook development, authority, fresh-review, validation, public-safety and documentation-maintenance rules;
- add a concise **Quick commands** table to the root README for `/go`, `/review`, `/plan`, `/implement`, `/fix`, `/handoff`, and `/status`;
- require `AGENTS.md` and `BOOTSTRAP` as maintained root artefacts and include `BOOTSTRAP` in public-safety validation;
- add regression checks that enforce the exact seven-command vocabulary across README, bootstrap guide, workflow router and AGENTS maintenance declaration;
- add regression coverage ensuring the standalone `BOOTSTRAP` text remains aligned with the copyable project-bootstrap block in `guides/project-bootstrap.md`.

The branch was reconciled onto current `main@2ac6be8576e6a5e0a96ad75478cd3d2cc6b1d96b`, preserving the newly added `BOOTSTRAP` file and treating it as part of the maintenance contract.

No command semantics, terminal states, authority boundaries, prompt bodies, maturity statuses, or consumer repositories are changed.

This authoring context will not claim a fresh independent substantive review of its own candidate. Repository CI is the executable validation gate.