### PR TITLE
Support single-maintainer fresh review flow

### DIFF
--- a/guides/project-bootstrap.md
+++ b/guides/project-bootstrap.md
@@ -48,6 +48,16 @@ Use the shorthand commands defined by the pinned Promptbook workflow router; do 
 
 Pinning a stable release makes the workflow dependency reproducible and reviewable. A repository may deliberately track `main` instead, but that opts into behaviour changes as Promptbook evolves. Keep the project-level bootstrap version-neutral and let the repository own the pin or override.
 
+## Single-maintainer projects
+
+A repository with one maintainer does not need to invent a second GitHub identity merely to obtain fresh review. Promptbook treats independence as a property of the reviewing context and evidence boundary. A fresh chat/session that independently reconstructs the candidate may still use the same maintainer account that authored the PR.
+
+If GitHub refuses a formal `APPROVE` or `REQUEST_CHANGES` review on the maintainer's own PR, record the exact disposition and rationale in a durable repository-local comment and continue the governing workflow when existing authority permits. That fallback is not a formal platform approval and must not bypass branch protection or repository policy that genuinely requires a distinct reviewer or approval status.
+
+After a fresh reviewer applies a bounded remediation, that context has become an authoring context for the changed candidate and cannot independently re-review its own change. Use another genuinely fresh context for the next independence-required gate; in a single-maintainer project that fresh context may still operate through the same GitHub account.
+
+Repositories with stronger separation-of-duties requirements should state them explicitly in `AGENTS.md` or other repository-local policy. Those requirements take precedence over this solo-maintainer default.
+
 ## Shorthand commands
 
 The canonical command semantics live in [`prompts/workflows/README.md`](../prompts/workflows/README.md). The small public vocabulary is:

--- a/prompts/workflows/README.md
+++ b/prompts/workflows/README.md
@@ -46,7 +46,7 @@ Use the first matching case:
    - Produce the handover only. Do not reinterpret a request for a prompt as authority to execute the handed-off task in the current context.
 
 2. **An independent substantive review is required now**.
-   - If the current context is genuinely fresh for that decision → [Fresh independent review](fresh-independent-review.md). Reconstruct the decision from the actual candidate and evidence rather than inheriting the authoring conclusion.
+   - If the current context is genuinely fresh for that decision → [Fresh independent review](fresh-independent-review.md). Reconstruct the decision from the actual candidate and evidence rather than inheriting the authoring conclusion. Freshness is about the context/evidence boundary; it does not require a different GitHub account unless repository-local policy explicitly requires a distinct reviewer identity.
    - If the current context is not genuinely fresh → [Next-session handover](next-session-handover.md). Produce a complete fresh-context review handoff and stop as `EXTERNAL_REQUIRED`; do not substitute author-side reasoning for independent evidence.
 
 3. **A newly supplied bounded approval or execution authority applies to the current proposal or action** → [Autonomous progression](autonomous-progression.md).
@@ -61,6 +61,14 @@ Use the first matching case:
 5. **No safe route fits** → fail closed.
    - Do not invent work, authority or a workflow mapping merely to keep moving.
    - Use the terminal-state rules below to identify the real boundary.
+
+## Single-maintainer repositories
+
+A single-person project may preserve independent review by using a genuinely fresh context while reusing the same repository owner/GitHub identity. Do not equate a distinct reviewer account with a fresh reasoning context unless repository-local policy, branch protection, regulation, or explicit task authority actually requires distinct identities.
+
+If the hosting platform refuses a formal self-review on an own PR, that platform limitation is not a terminal state by itself. Record the exact `APPROVED` / `CHANGES REQUIRED` disposition and concise rationale in a durable repository-local comment or other permitted record, then continue the governing workflow according to existing authority. Do not invent another account, fake formal approval, or bypass a rule that genuinely requires a formal or distinct-person approval.
+
+For an intermediate `CHANGES REQUIRED`, perform an objectively determined, already-authorised minimum-safe remediation and validation before stopping. The context that performs that remediation is no longer fresh for the changed candidate, so route the exact remediated candidate to a new genuinely fresh context; that new context may still operate through the same maintainer account. For `APPROVED`, continue already-authorised merge, verification and close-out even when a formal self-approval cannot be recorded, unless repository rules make that formal status a real prerequisite.
 
 ## Terminal states
 
@@ -82,7 +90,7 @@ Review readiness, validation results, PR readiness, merge readiness and ordinary
 - Prefer the minimum safe change and fail closed when decision-critical evidence is missing.
 - Do not ask for routine `proceed` confirmations when existing authority and evidence already determine the safe action.
 - Output or deliverable constraints inside a selected workflow apply to that workflow's record. They do not override this router's continuation semantics unless the user or governing task explicitly requested that workflow result as the final deliverable.
-- A fresh review disposition does not itself create mutation authority. When fresh review is an intermediate gate under this router, record its single clear disposition and concise rationale, then return control to the governing workflow. If `CHANGES REQUIRED` identifies a bounded defect whose minimum-safe remediation is objectively determined and already authorised, continue through autonomous progression to remediate and validate it without another routine approval. Because that context then authored the changed candidate, route the new candidate to a genuinely fresh review context before any gate requiring independence. If the disposition is `APPROVED`, continue already-authorised merge, verification and close-out work rather than stopping at review completion.
+- A fresh review disposition does not itself create mutation authority. When fresh review is an intermediate gate under this router, record its single clear disposition and concise rationale, then return control to the governing workflow. If `CHANGES REQUIRED` identifies a bounded defect whose minimum-safe remediation is objectively determined and already authorised, continue through autonomous progression to remediate and validate it without another routine approval. Because that context then authored the changed candidate, route the new candidate to a genuinely fresh review context before any gate requiring independence. A single-maintainer project may use the same GitHub identity in that new fresh context. If the disposition is `APPROVED`, continue already-authorised merge, verification and close-out work rather than stopping at review completion or at a platform refusal to record formal self-approval, unless repository-local rules make that approval status mandatory.
 - A requested handover is terminal for the current deliverable; execution belongs to the receiving context.
 - Do not invent adjacent work after the governed objective is complete.
 

--- a/prompts/workflows/fresh-independent-review.md
+++ b/prompts/workflows/fresh-independent-review.md
@@ -17,15 +17,19 @@ Treat prior summaries, recommendations, and conclusions only as navigation aids.
 
 Reach the substantive conclusion from freshly inspected evidence. Do not inherit the prior session's approval/rejection reasoning, do not weaken the governing contract to obtain approval, and distinguish blocking findings from non-blocking observations.
 
+Fresh independence is a property of this reviewing context and its information boundary, not automatically of the GitHub account used to record the result. In a single-maintainer repository, a genuinely fresh context may use the same maintainer account that authored the PR. Do not treat same-account operation as a loss of independence unless repository-local policy, branch protection, regulation, or explicit task authority requires a distinct reviewer identity.
+
+If the hosting platform refuses a formal self-review such as APPROVE or REQUEST_CHANGES on the maintainer's own PR, treat that as a recording limitation rather than a governance stop by itself. Record the exact disposition and concise rationale in a durable PR comment, review comment, issue comment, or other repository-local record permitted by policy, then return control to the governing workflow. Do not invent another identity, bypass a required approval, or represent the fallback record as a formal platform approval.
+
 If expected state changed, determine what changed and whether the review remains safely decidable; do not fail mechanically merely because an identity moved when the governing contract permits reconciliation.
 
 Return exactly one clear disposition appropriate to the gate (for example APPROVED / CHANGES REQUIRED), followed by concise decisive rationale. For a negative disposition, identify only material blockers that must be resolved.
 
 That single disposition is the review record. If this review was explicitly requested as the final deliverable, stop after recording it. If a governing workflow or router invoked this review as an intermediate gate, return control to that workflow after recording the disposition; do not treat review completion itself as a terminal state.
 
-A review result never creates mutation authority. If CHANGES REQUIRED identifies a bounded defect whose minimum-safe remediation is objectively determined and already authorised by the governing task, the governing workflow may perform and validate that remediation without another routine approval. Once this context authors or materially shapes the changed candidate, it must not claim a fresh independent review of that changed candidate; route it to a genuinely fresh review context before any gate that requires independence.
+A review result never creates mutation authority. If CHANGES REQUIRED identifies a bounded defect whose minimum-safe remediation is objectively determined and already authorised by the governing task, the governing workflow may perform and validate that remediation without another routine approval. Once this context authors or materially shapes the changed candidate, it must not claim a fresh independent review of that changed candidate; route it to a genuinely fresh review context before any gate that requires independence. In a single-maintainer repository, that new fresh context may still use the same GitHub maintainer identity.
 
-If the disposition is APPROVED, the governing workflow may continue any already-authorised merge, verification, and close-out work. Do not stop merely because the review gate completed when the overall governed task still has authorised, safely decidable work remaining.
+If the disposition is APPROVED, the governing workflow may continue any already-authorised merge, verification, and close-out work. Do not stop merely because the review gate completed or because the platform could not record a formal self-approval when the overall governed task still has authorised, safely decidable work remaining. If repository rules genuinely require a distinct reviewer identity or formal approval status, preserve that requirement and fail or hand off according to the governing workflow rather than bypassing it.
 ```
 
 ## Inputs
@@ -35,11 +39,11 @@ If the disposition is APPROVED, the governing workflow may continue any already-
 
 ## What it does
 
-Creates an information boundary between authoring and adjudication and forces the reviewer to inspect the real evidence rather than merely validating a handover summary. When composed inside a governing workflow, it records the independent disposition without turning review completion into an unnecessary conversational stop.
+Creates an information boundary between authoring and adjudication and forces the reviewer to inspect the real evidence rather than merely validating a handover summary. When composed inside a governing workflow, it records the independent disposition without turning review completion into an unnecessary conversational stop. It also separates reasoning independence from hosting-platform reviewer identity so single-maintainer projects can retain fresh-context review without inventing extra accounts or false approval gates.
 
 ## Boundaries / limitations
 
-Freshness is a property of prior information, not a prompt incantation. A context that substantially authored the candidate or already saw the expected answer cannot become independent merely by being told to forget it. The review result does not grant mutation authority; any remediation or continuation must already be authorised by the governing task or workflow.
+Freshness is a property of prior information, not a prompt incantation or a different account name. A context that substantially authored the candidate or already saw the expected answer cannot become independent merely by being told to forget it, even if it uses another account. Conversely, a genuinely fresh context does not cease to be independent merely because a single-maintainer project must use the same GitHub identity. Repository-local requirements for distinct reviewers or formal approvals still take precedence. The review result does not grant mutation authority; any remediation or continuation must already be authorised by the governing task or workflow.
 
 ## Status
 

--- a/tests/test_validate_promptbook.py
+++ b/tests/test_validate_promptbook.py
@@ -109,6 +109,18 @@ class PromptbookValidationTests(unittest.TestCase):
         for pattern in MODULE.PRIVATE_PATTERNS.values():
             self.assertNotIn(pattern, text)
 
+    def test_single_maintainer_router_contract(self):
+        text = (ROOT / "prompts" / "workflows" / "README.md").read_text(encoding="utf-8")
+        lower = text.lower()
+
+        self.assertIn("single-maintainer repositories", lower)
+        self.assertIn("same repository owner/github identity", lower)
+        self.assertIn("platform limitation is not a terminal state by itself", lower)
+        self.assertIn("durable repository-local comment", lower)
+        self.assertIn("may still operate through the same maintainer account", lower)
+        self.assertIn("branch protection", lower)
+        self.assertIn("does not itself create mutation authority", lower)
+
     def test_fresh_review_composition_contract(self):
         text = (
             ROOT / "prompts" / "workflows" / "fresh-independent-review.md"
@@ -125,6 +137,21 @@ class PromptbookValidationTests(unittest.TestCase):
 
         for pattern in MODULE.PRIVATE_PATTERNS.values():
             self.assertNotIn(pattern, text)
+
+    def test_single_maintainer_fresh_review_contract(self):
+        text = (
+            ROOT / "prompts" / "workflows" / "fresh-independent-review.md"
+        ).read_text(encoding="utf-8")
+        lower = text.lower()
+
+        self.assertIn("not automatically of the github account", lower)
+        self.assertIn("same maintainer account", lower)
+        self.assertIn("recording limitation rather than a governance stop by itself", lower)
+        self.assertIn("durable pr comment", lower)
+        self.assertIn("must not claim a fresh independent review", lower)
+        self.assertIn("same github maintainer identity", lower)
+        self.assertIn("distinct reviewer identity", lower)
+        self.assertIn("review result never creates mutation authority", lower)
 
     def test_project_bootstrap_contract(self):
         path = ROOT / "guides" / "project-bootstrap.md"
@@ -156,6 +183,18 @@ class PromptbookValidationTests(unittest.TestCase):
 
         for pattern in MODULE.PRIVATE_PATTERNS.values():
             self.assertNotIn(pattern, text)
+
+    def test_single_maintainer_bootstrap_guidance(self):
+        text = (ROOT / "guides" / "project-bootstrap.md").read_text(encoding="utf-8")
+        lower = text.lower()
+
+        self.assertIn("single-maintainer projects", lower)
+        self.assertIn("does not need to invent a second github identity", lower)
+        self.assertIn("fresh chat/session", lower)
+        self.assertIn("durable repository-local comment", lower)
+        self.assertIn("must not bypass branch protection", lower)
+        self.assertIn("same github account", lower)
+        self.assertIn("separation-of-duties", lower)
 
     def test_public_command_docs_stay_aligned(self):
         surfaces = (


### PR DESCRIPTION
Closes #12.

Separates fresh-context independence from GitHub reviewer identity for single-maintainer repositories.

This candidate:
- defines independence as a context/evidence-boundary property rather than automatically requiring a distinct GitHub account;
- treats GitHub self-review rejection as a recording limitation, not a lifecycle stop by itself;
- permits durable comment fallback without pretending it is formal approval;
- continues already-authorised bounded remediation or merge progression;
- requires a genuinely fresh context after remediation, while allowing that context to use the same maintainer identity;
- preserves repository policy, branch protection, formal approval and separation-of-duties requirements when they actually exist;
- preserves standalone `/review` as review-only unless continuation is requested;
- adds public bootstrap guidance and regression coverage.

No new command, authority grant, branch-protection bypass, fake reviewer identity, maturity change or consumer-repository mutation is introduced.

This authoring context does not claim fresh independent review of its own candidate; exact-head CI and bounded scope verification are the author-side merge gates authorised by #12.