### PR TITLE
Add recommendation-first decision capsules

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Promptbook is for engineers and technical practitioners who want AI assistants t
 | Turn an issue into an implementation plan | [Plan an issue](prompts/engineering/plan-an-issue.md) |
 | Review a pull request substantively | [Review a pull request](prompts/engineering/pr-review.md) |
 | Continue governed work or determine the next workflow | [Workflow router](prompts/workflows/README.md) |
+| Respond quickly to a genuine human decision | [Decision capsules](guides/decision-capsules.md) |
 | Set up recurring project-chat invocation | [Project bootstrap and shorthand commands](guides/project-bootstrap.md) |
 | Re-review work from a fresh context | [Fresh independent review](prompts/workflows/fresh-independent-review.md) |
 
@@ -40,6 +41,22 @@ Examples:
 ```
 
 Commands are shorthand intent selectors only. They do not grant authority or bypass repository-local instructions, validation, security controls, freshness, or independent-review requirements. See [Project bootstrap and shorthand commands](guides/project-bootstrap.md) for setup and the [Workflow router](prompts/workflows/README.md) for canonical command semantics.
+
+## Decision capsules
+
+When Promptbook genuinely needs a human judgement or authority decision, it presents the recommendation and choices first instead of making you copy an approval phrase or repository identifier:
+
+```text
+DECISION_REQUIRED — Deployment mechanism
+
+Recommended: A
+
+A — GitHub Actions + Workload Identity
+B — Cloud Build
+C — Defer
+```
+
+You can answer naturally with `A`, `Choose A`, `accept`, `go ahead`, or another clear equivalent when there is exactly one unambiguous pending decision. The stable protocol is semantic `ACCEPT`, `REJECT`, `CHOOSE`, and `CHANGE` intent, so the same interaction works from keyboard, touch, or voice. See [Decision capsules](guides/decision-capsules.md) for binding, ambiguity, stale-proposal, and continuation rules.
 
 ## How to use Promptbook
 
@@ -73,6 +90,7 @@ Status describes the evidence behind the Promptbook prompt. It is not a claim of
 
 - [Using Promptbook](guides/using-promptbook.md)
 - [Project bootstrap and shorthand commands](guides/project-bootstrap.md)
+- [Decision capsules](guides/decision-capsules.md)
 - [Adapting prompts](guides/adapting-prompts.md)
 - [Design principles](guides/design-principles.md)
 

--- a/guides/decision-capsules.md
+++ b/guides/decision-capsules.md
@@ -1,0 +1,105 @@
+# Decision capsules
+
+Decision capsules are Promptbook's device-neutral handoff for a genuine `DECISION_REQUIRED` boundary. They make the smallest human choice obvious without requiring the user to copy repository identifiers or remember exact command syntax.
+
+The governing principle is:
+
+> Recommendation and choices first; governance detail second. Semantic intents are the stable protocol; keyboard, touch, natural language and voice are input adapters.
+
+## Multiple-choice decisions
+
+When there are several meaningful alternatives, present compact labelled choices:
+
+```text
+DECISION_REQUIRED — Deployment mechanism
+
+Recommended: A
+
+A — GitHub Actions + Workload Identity
+B — Cloud Build
+C — Defer
+```
+
+A user may respond with `A`, `Choose A`, `go with A`, the option name, or another clear equivalent when that decision is the only unresolved referent.
+
+## Bounded approval decisions
+
+When the question is whether to accept one concrete bounded proposal, do not manufacture A/B/C. Use semantic choices:
+
+```text
+DECISION_REQUIRED — Apply repository protection?
+
+Recommended: ACCEPT
+
+ACCEPT — Apply the approved bounded settings
+REJECT — Do not apply them
+CHANGE — Revise the proposal
+```
+
+Material authority, risk, cost, or security detail may follow below the choices when it changes what the human is deciding.
+
+## Semantic intents
+
+The stable interaction contract is:
+
+- `ACCEPT` — accept the recommended bounded option for the current decision;
+- `REJECT` — reject only the presented proposal or option;
+- `CHOOSE <option>` — select a specific presented alternative;
+- `CHANGE <instruction>` — request a revision to the proposal without approving that revision.
+
+These are semantic intents rather than mandatory commands. Clear equivalents can be expressed by keyboard, touch, or voice, for example:
+
+```text
+A
+Choose B
+yes
+go ahead
+accept the recommendation
+use Cloud Build
+reject
+change: keep the ruleset but defer secret scanning
+```
+
+Slash aliases such as `/accept` or `/choose B` may be understood as conveniences, but Promptbook does not require them and they are not part of the public shorthand-command vocabulary.
+
+## Decision binding
+
+A decision capsule must be bound to one concrete unresolved decision. The agent should retain enough authoritative identity to know what the response applies to, including:
+
+- the decision target;
+- the proposal or revision identity;
+- the recommended choice;
+- the bounded authority or effect granted by acceptance.
+
+The human should not normally need to repeat those identifiers.
+
+Before consequential mutation after `ACCEPT` or `CHOOSE`, refresh decision-critical state. If the proposal materially changed, do not migrate the earlier response to the new proposal. Re-present the decision instead.
+
+Accepted authority is consumed once for the bounded object only. If existing governance already authorises the routine implementation, validation, review/merge progression, verification, or close-out that follows, continue automatically without another `proceed` confirmation.
+
+## Rejecting and changing
+
+`REJECT` is deliberately non-destructive. It does not automatically close the issue, abandon the overall objective, undo completed work, or select another option. Reconstruct the changed decision state and present another recommendation when one is safely determined.
+
+`CHANGE` asks for a revision. The revised proposal must be re-presented for decision unless the user's wording explicitly grants authority for that revised proposal. A request to change something is not implicit approval of whatever revision results.
+
+## Ambiguity and voice
+
+Short responses are useful on phones, tablets, laptops and voice interfaces, but only when their referent is clear.
+
+If exactly one unresolved decision exists, responses such as `yes`, `A`, `accept`, `go ahead`, or a spoken option name may be safely interpreted from context. If more than one unresolved decision or plausible referent exists, fail closed and ask which decision the user means rather than guessing authority.
+
+If natural language conflicts with the presented labels, follow the explicit meaning rather than forcing the response into a predefined intent. For example, `Choose B but keep the current authentication model` is a choice plus a material qualifier and should be evaluated as such.
+
+## Relationship to `/go`
+
+Decision responses and `/go` serve different purposes:
+
+- `/go` means continue work where no new human decision is required;
+- `ACCEPT` or `CHOOSE` grants/selects the specific bounded decision just presented.
+
+A valid accepted decision should return control to governed autonomous progression immediately when the remaining work is already authorised.
+
+## Precedence
+
+Decision capsules never override repository-local instructions, explicit task authority, branch protection, security controls, validation requirements, fresh-review boundaries, or platform safety constraints. They improve the human handoff; they do not weaken the governance boundary that required the decision.

--- a/guides/using-promptbook.md
+++ b/guides/using-promptbook.md
@@ -33,3 +33,5 @@ If the conflict changes what is authorised or materially changes the intended ou
 For project chats or other persistent workspaces, do not copy Promptbook prompt bodies into project instructions. Use a thin bootstrap that points the agent at repository-local instructions and the Promptbook workflow router, and let the repository declare any Promptbook version/pin. The router owns the public shorthand command vocabulary such as `/go`, `/review`, `/fix`, and `/status`.
 
 See [Project bootstrap and shorthand commands](project-bootstrap.md) for copyable bootstrap text, an `AGENTS.md` declaration pattern, command semantics, and versioning guidance.
+
+When the router reaches a genuine human choice, use the [decision capsule](decision-capsules.md) interaction rather than copying repository identifiers into an approval sentence. Recommendation-first choices and semantic `ACCEPT`, `REJECT`, `CHOOSE`, and `CHANGE` intents are designed to work consistently across keyboard, touch and voice while preserving bounded authority.

--- a/prompts/workflows/README.md
+++ b/prompts/workflows/README.md
@@ -50,7 +50,7 @@ Use the first matching case:
    - If the current context is not genuinely fresh → [Next-session handover](next-session-handover.md). Produce a complete fresh-context review handoff and stop as `EXTERNAL_REQUIRED`; do not substitute author-side reasoning for independent evidence.
 
 3. **A newly supplied bounded approval or execution authority applies to the current proposal or action** → [Autonomous progression](autonomous-progression.md).
-   - Identify the exact proposal or action being authorised.
+   - Identify the exact proposal or action being authorised. An unambiguous response to the current decision capsule, such as `A`, `accept`, `choose B`, or an equivalent natural-language/voice response, may supply that authority or choice.
    - Refresh decision-critical state and verify that the proposal/action and its authority boundary remain materially unchanged.
    - Consume the approval or authority once, only for that bounded object, then continue routine governed work through autonomous progression.
    - Do not treat approval as authority to expand scope, weaken controls or accept a materially changed proposal. Escalate a genuinely new human choice as `DECISION_REQUIRED`.
@@ -70,12 +70,61 @@ If the hosting platform refuses a formal self-review on an own PR, that platform
 
 For an intermediate `CHANGES REQUIRED`, perform an objectively determined, already-authorised minimum-safe remediation and validation before stopping. The context that performs that remediation is no longer fresh for the changed candidate, so route the exact remediated candidate to a new genuinely fresh context; that new context may still operate through the same maintainer account. For `APPROVED`, continue already-authorised merge, verification and close-out even when a formal self-approval cannot be recorded, unless repository rules make that formal status a real prerequisite.
 
+## Decision capsules
+
+When a genuine human decision is required, do not end with a repository identifier or approval sentence the user must copy. Present the smallest concrete decision as a compact recommendation-first **decision capsule**.
+
+For multiple meaningful alternatives, use compact option labels:
+
+```text
+DECISION_REQUIRED — Deployment mechanism
+
+Recommended: A
+
+A — GitHub Actions + Workload Identity
+B — Cloud Build
+C — Defer
+```
+
+For approval of one bounded proposal, use semantic choices rather than manufacturing A/B/C:
+
+```text
+DECISION_REQUIRED — Apply repository protection?
+
+Recommended: ACCEPT
+
+ACCEPT — Apply the approved bounded settings
+REJECT — Do not apply them
+CHANGE — Revise the proposal
+```
+
+Put recommendation and choices first. Add material authority, risk, or governance detail below the choices only when it affects the decision.
+
+The canonical response protocol is semantic intent, not slash-command syntax:
+
+- `ACCEPT` — accept the recommended bounded option;
+- `REJECT` — reject only the presented proposal or choice;
+- `CHOOSE <option>` — select a presented option;
+- `CHANGE <instruction>` — request a revision without approving the revision.
+
+Clear natural-language, short-form, touch, or voice equivalents may express the same intent when exactly one unresolved decision and its referent are unambiguous. Examples include `A`, `Choose A`, `yes`, `go ahead`, `accept the recommendation`, or naming the option directly. Slash aliases may be understood as conveniences, but they are not the protocol and are not added to the public shorthand-command vocabulary.
+
+Bind every capsule to one concrete unresolved decision and the authoritative proposal/evidence needed to interpret it: the decision target, proposal or revision identity, recommendation, and bounded authority/effect of acceptance. The user should not normally need to repeat those identifiers.
+
+Before consequential mutation after `ACCEPT` or `CHOOSE`, refresh decision-critical state. If the proposal materially changed, do not silently migrate the earlier response to the new proposal; re-present the decision. Consume accepted authority once for the bounded object only, then resume governed autonomous progression immediately when existing authority permits it.
+
+`REJECT` does not implicitly close the issue, abandon the objective, undo prior work, or choose another option. Re-route from the changed decision state and present another recommendation when one is safely determined. `CHANGE` requests revision; after revising, re-present the decision unless the user's wording explicitly grants authority for the revised proposal.
+
+If more than one unresolved decision exists, or a short response such as `yes`, `A`, or `accept` has more than one plausible referent, fail closed rather than guessing. Repository-local policy, validation, security controls, branch protection, and explicit task authority continue to take precedence.
+
+See [Decision capsules](../../guides/decision-capsules.md) for the device-neutral interaction pattern and examples.
+
 ## Terminal states
 
 A routed task should end only as one of these states:
 
 - `EXTERNAL_REQUIRED` — the next required action cannot legitimately be performed in the current environment, but a complete executable handoff can resolve it.
-- `DECISION_REQUIRED` — a genuine human judgement or authority decision is required.
+- `DECISION_REQUIRED` — a genuine human judgement or authority decision is required; present it as a recommendation-first decision capsule.
 - `BLOCKED` — no safe autonomous action, executable external handoff or concrete human decision can resolve the condition now.
 - `COMPLETE` — the governed objective is genuinely finished, including required verification and close-out.
 
@@ -89,6 +138,7 @@ Review readiness, validation results, PR readiness, merge readiness and ordinary
 - Treat access or capability as distinct from permission.
 - Prefer the minimum safe change and fail closed when decision-critical evidence is missing.
 - Do not ask for routine `proceed` confirmations when existing authority and evidence already determine the safe action.
+- When `DECISION_REQUIRED` applies, present the decision capsule instead of making the user copy an approval phrase or repository identifier. Once an unambiguous `ACCEPT` or `CHOOSE` response is safely bound and refreshed, continue any already-authorised routine work without another `proceed` confirmation.
 - Output or deliverable constraints inside a selected workflow apply to that workflow's record. They do not override this router's continuation semantics unless the user or governing task explicitly requested that workflow result as the final deliverable.
 - A fresh review disposition does not itself create mutation authority. When fresh review is an intermediate gate under this router, record its single clear disposition and concise rationale, then return control to the governing workflow. If `CHANGES REQUIRED` identifies a bounded defect whose minimum-safe remediation is objectively determined and already authorised, continue through autonomous progression to remediate and validate it without another routine approval. Because that context then authored the changed candidate, route the new candidate to a genuinely fresh review context before any gate requiring independence. A single-maintainer project may use the same GitHub identity in that new fresh context. If the disposition is `APPROVED`, continue already-authorised merge, verification and close-out work rather than stopping at review completion or at a platform refusal to record formal self-approval, unless repository-local rules make that approval status mandatory.
 - A requested handover is terminal for the current deliverable; execution belongs to the receiving context.

--- a/prompts/workflows/autonomous-progression.md
+++ b/prompts/workflows/autonomous-progression.md
@@ -29,9 +29,17 @@ Escalate only as one of these states:
 - BLOCKED — no safe action, external handoff, or concrete human decision can resolve the condition now;
 - COMPLETE — the governed objective is genuinely finished and required verification/close-out is done.
 
+When DECISION_REQUIRED applies, present the smallest concrete decision as a recommendation-first decision capsule. Put the recommendation and viable choices before supporting governance detail. For multiple meaningful alternatives, use compact labels such as A / B / C. For approval of one bounded proposal, use semantic choices such as ACCEPT / REJECT / CHANGE rather than manufacturing artificial alternatives.
+
+Treat ACCEPT, REJECT, CHOOSE <option>, and CHANGE <instruction> as semantic intents, not required command syntax. Clear natural-language equivalents such as “yes”, “go ahead”, “choose B”, or a spoken option name may express the same intent only when exactly one unresolved decision and its referent are unambiguous. Do not guess when multiple decisions or meanings are plausible.
+
+Bind the capsule to the concrete decision target, proposal/revision identity, recommendation, and bounded effect of acceptance. Before consequential mutation after ACCEPT or CHOOSE, refresh decision-critical state. If the proposal materially changed, do not migrate stale approval; re-present the decision. Consume accepted authority once for that bounded object, then resume autonomous progression immediately when existing authority permits.
+
+REJECT rejects only the presented proposal or choice; it does not implicitly close the objective, undo prior work, or select an alternative. CHANGE requests a revision and is not approval of the revised proposal unless the user explicitly says so.
+
 When a bounded defect has an objectively determined minimum-safe remediation inside the existing contract, remediate and validate it without asking for another routine approval. Do not invent adjacent work merely to keep moving.
 
-Before ending, state why stopping is necessary. If none of EXTERNAL_REQUIRED, DECISION_REQUIRED, BLOCKED, or COMPLETE applies, continue the next authorised action.
+Before ending, state why stopping is necessary. If DECISION_REQUIRED applies, use the decision capsule instead of giving the human a repository identifier or approval sentence to copy. If none of EXTERNAL_REQUIRED, DECISION_REQUIRED, BLOCKED, or COMPLETE applies, continue the next authorised action.
 ```
 
 ## Inputs
@@ -40,11 +48,11 @@ Before ending, state why stopping is necessary. If none of EXTERNAL_REQUIRED, DE
 
 ## What it does
 
-Separates genuine human decisions and capability boundaries from ordinary lifecycle status, reducing repeated “proceed?” interactions while retaining fail-closed behaviour.
+Separates genuine human decisions and capability boundaries from ordinary lifecycle status, reducing repeated “proceed?” interactions while retaining fail-closed behaviour. When a human decision is genuinely required, it presents a compact device-neutral decision capsule and resumes governed work after an unambiguous bounded response.
 
 ## Boundaries / limitations
 
-This prompt never overrides repository-local policy or grants credentials, production authority, destructive-action authority, or permission to widen scope. Autonomy is limited to actions already justified by the governing objective and evidence.
+This prompt never overrides repository-local policy or grants credentials, production authority, destructive-action authority, or permission to widen scope. Autonomy is limited to actions already justified by the governing objective and evidence. Short natural-language or voice responses are authority only when their decision referent is unambiguous; materially changed proposals must be re-presented rather than inheriting stale acceptance.
 
 ## Status
 

--- a/tests/test_validate_promptbook.py
+++ b/tests/test_validate_promptbook.py
@@ -121,6 +121,48 @@ class PromptbookValidationTests(unittest.TestCase):
         self.assertIn("branch protection", lower)
         self.assertIn("does not itself create mutation authority", lower)
 
+    def test_decision_capsule_router_contract(self):
+        text = (ROOT / "prompts" / "workflows" / "README.md").read_text(encoding="utf-8")
+        lower = text.lower()
+
+        self.assertIn("## Decision capsules", text)
+        self.assertIn("recommendation-first", lower)
+        self.assertIn("Recommended: A", text)
+        self.assertIn("Recommended: ACCEPT", text)
+        for intent in ("`ACCEPT`", "`REJECT`", "`CHOOSE <option>`", "`CHANGE <instruction>`"):
+            self.assertIn(intent, text)
+        self.assertIn("natural-language", lower)
+        self.assertIn("voice", lower)
+        self.assertIn("exactly one unresolved decision", lower)
+        self.assertIn("do not silently migrate", lower)
+        self.assertIn("consume accepted authority once", lower)
+        self.assertIn("does not implicitly close the issue", lower)
+        self.assertIn("requests revision", lower)
+        self.assertIn("without another `proceed` confirmation", lower)
+        self.assertIn("repository-local policy", lower)
+        self.assertIn("validation", lower)
+        self.assertIn("security controls", lower)
+
+    def test_autonomous_progression_decision_capsule_contract(self):
+        text = (
+            ROOT / "prompts" / "workflows" / "autonomous-progression.md"
+        ).read_text(encoding="utf-8")
+        lower = text.lower()
+
+        self.assertIn("recommendation-first decision capsule", lower)
+        self.assertIn("a / b / c", lower)
+        self.assertIn("accept / reject / change", lower)
+        self.assertIn("semantic intents, not required command syntax", lower)
+        self.assertIn("natural-language", lower)
+        self.assertIn("voice", lower)
+        self.assertIn("do not guess", lower)
+        self.assertIn("proposal/revision identity", lower)
+        self.assertIn("do not migrate stale approval", lower)
+        self.assertIn("consume accepted authority once", lower)
+        self.assertIn("resume autonomous progression immediately", lower)
+        self.assertIn("reject rejects only the presented proposal", lower)
+        self.assertIn("change requests a revision", lower)
+
     def test_fresh_review_composition_contract(self):
         text = (
             ROOT / "prompts" / "workflows" / "fresh-independent-review.md"
@@ -195,6 +237,34 @@ class PromptbookValidationTests(unittest.TestCase):
         self.assertIn("must not bypass branch protection", lower)
         self.assertIn("same github account", lower)
         self.assertIn("separation-of-duties", lower)
+
+    def test_decision_capsule_guide_contract(self):
+        path = ROOT / "guides" / "decision-capsules.md"
+        text = path.read_text(encoding="utf-8")
+        lower = text.lower()
+
+        self.assertIn("Recommendation and choices first", text)
+        self.assertIn("Recommended: A", text)
+        self.assertIn("Recommended: ACCEPT", text)
+        for intent in ("`ACCEPT`", "`REJECT`", "`CHOOSE <option>`", "`CHANGE <instruction>`"):
+            self.assertIn(intent, text)
+        self.assertIn("keyboard, touch", lower)
+        self.assertIn("voice", lower)
+        self.assertIn("one concrete unresolved decision", lower)
+        self.assertIn("do not migrate the earlier response", lower)
+        self.assertIn("consumed once", lower)
+        self.assertIn("does not automatically close the issue", lower)
+        self.assertIn("not implicit approval", lower)
+        self.assertIn("fail closed", lower)
+        self.assertIn("/go", text)
+        self.assertIn("repository-local instructions", lower)
+
+        readme = (ROOT / "README.md").read_text(encoding="utf-8")
+        using = (ROOT / "guides" / "using-promptbook.md").read_text(encoding="utf-8")
+        router = (ROOT / "prompts" / "workflows" / "README.md").read_text(encoding="utf-8")
+        self.assertIn("guides/decision-capsules.md", readme)
+        self.assertIn("decision-capsules.md", using)
+        self.assertIn("../../guides/decision-capsules.md", router)
 
     def test_public_command_docs_stay_aligned(self):
         surfaces = (


### PR DESCRIPTION
Closes #14.

Implements the approved device-neutral decision interaction contract without changing the existing seven-command vocabulary.

Scope:
- make `DECISION_REQUIRED` emit recommendation-first decision capsules;
- define semantic `ACCEPT`, `REJECT`, `CHOOSE`, and `CHANGE` intents;
- accept unambiguous natural-language/voice equivalents without requiring slash syntax;
- bind responses to one concrete proposal/revision and fail closed on ambiguity or stale state;
- keep `REJECT` non-destructive and `CHANGE` non-approving;
- resume already-authorised governed progression after a valid accepted/selected decision;
- publish focused public guidance and regression coverage.

No release, bootstrap-pin, command-vocabulary, maturity, repository-security, credential, production, or unrelated taxonomy change is included.

Owner implementation authority is recorded on #14 comment `5307353070`. This authoring context does not claim fresh independent review of its own candidate.