### PR TITLE
Adopt Diátaxis documentation assessment workflow route

### DIFF
--- a/prompts/README.md
+++ b/prompts/README.md
@@ -13,11 +13,12 @@ Promptbook is organised by the task a user wants to perform.
 
 - [Workflow router — start here for governed continuation](workflows/README.md)
 - [Autonomous progression](workflows/autonomous-progression.md)
+- [Documentation assessment workflow](workflows/documentation-assessment.md)
 - [Fresh independent review](workflows/fresh-independent-review.md)
 - [Next-session handover](workflows/next-session-handover.md)
 
 ## Documentation
 
-- [Repository documentation assessment](documentation/repository-assessment.md)
+- [Repository documentation assessment — one known reader task](documentation/repository-assessment.md)
 
 New categories should be added only when they contain a real reusable prompt, not to reserve taxonomy in advance.

--- a/prompts/documentation/repository-assessment.md
+++ b/prompts/documentation/repository-assessment.md
@@ -2,11 +2,11 @@
 
 ## Purpose
 
-Assess whether repository documentation lets a defined reader complete a real task safely, rather than reviewing documentation for style or coverage in the abstract.
+Assess whether repository documentation lets a defined reader complete one known task safely, rather than reviewing documentation for style or coverage in the abstract.
 
 ## When to use
 
-Use when you need evidence about navigation, authority, missing/contradictory documentation, or the smallest useful documentation improvement for a repository task.
+Use as the proportionate Level-1/single-task path when the concrete reader task is already known and you need evidence about navigation, authority, missing/contradictory documentation, or the smallest useful documentation improvement for that task. For broader repository assessment where reader groups or representative tasks still need to be discovered or approved, use the [Documentation assessment workflow](../workflows/documentation-assessment.md).
 
 ## Prompt
 
@@ -40,11 +40,11 @@ Return one primary result: COMPLETE, PARTIAL, BLOCKED, or NOT TESTED, with conci
 
 ## What it does
 
-Evaluates documentation through an actual task path, preserves authority boundaries, and allows “no change” or “blocked by missing decision” to be valid outcomes.
+Evaluates documentation through one actual task path, preserves authority boundaries, and allows “no change” or “blocked by missing decision” to be valid outcomes. It intentionally avoids the reader/task discovery and approval machinery needed for a broader Level-2 assessment.
 
 ## Boundaries / limitations
 
-This is an assessment prompt, not automatic remediation authority. The quality of the result depends on a realistic reader task and access to the documentation sources that actually govern it.
+This is an assessment prompt, not automatic remediation authority. The quality of the result depends on a realistic, already-known reader task and access to the documentation sources that actually govern it. If the reader task itself is still uncertain, use the broader documentation-assessment workflow first.
 
 ## Status
 

--- a/prompts/workflows/README.md
+++ b/prompts/workflows/README.md
@@ -55,10 +55,15 @@ Use the first matching case:
    - Consume the approval or authority once, only for that bounded object, then continue routine governed work through autonomous progression.
    - Do not treat approval as authority to expand scope, weaken controls or accept a materially changed proposal. Escalate a genuinely new human choice as `DECISION_REQUIRED`.
 
-4. **Ordinary governed continuation** → [Autonomous progression](autonomous-progression.md).
+4. **A substantive repository documentation assessment is needed and the representative reader tasks are not already known** → [Documentation assessment workflow](documentation-assessment.md).
+   - Use this route for broad documentation-quality assessment, navigation or authority problems, or deciding the smallest justified documentation response when reader/task discovery is part of the work.
+   - Do not route ordinary bounded documentation edits, known corrections or explicit drafting tasks through assessment merely because documentation is involved.
+   - If one concrete reader task is already known and no multi-task discovery is needed, use [Repository documentation assessment](../documentation/repository-assessment.md) as the proportionate single-task path.
+
+5. **Ordinary governed continuation** → [Autonomous progression](autonomous-progression.md).
    - Continue while current policy, evidence, scope and available capabilities safely determine the next action.
 
-5. **No safe route fits** → fail closed.
+6. **No safe route fits** → fail closed.
    - Do not invent work, authority or a workflow mapping merely to keep moving.
    - Use the terminal-state rules below to identify the real boundary.
 
@@ -147,5 +152,6 @@ Review readiness, validation results, PR readiness, merge readiness and ordinary
 ## Current workflows
 
 - [Autonomous progression](autonomous-progression.md) — continue already-governed work with minimal human orchestration.
+- [Documentation assessment workflow](documentation-assessment.md) — discover and approve representative reader tasks, then continue a substantive documentation assessment with a pinned external method.
 - [Fresh independent review](fresh-independent-review.md) — reconstruct and adjudicate a candidate from a genuinely fresh context.
 - [Next-session handover](next-session-handover.md) — create the shortest safe continuation prompt for another context or capability boundary.

--- a/prompts/workflows/README.md
+++ b/prompts/workflows/README.md
@@ -55,10 +55,10 @@ Use the first matching case:
    - Consume the approval or authority once, only for that bounded object, then continue routine governed work through autonomous progression.
    - Do not treat approval as authority to expand scope, weaken controls or accept a materially changed proposal. Escalate a genuinely new human choice as `DECISION_REQUIRED`.
 
-4. **A substantive repository documentation assessment is needed and the representative reader tasks are not already known** → [Documentation assessment workflow](documentation-assessment.md).
-   - Use this route for broad documentation-quality assessment, navigation or authority problems, or deciding the smallest justified documentation response when reader/task discovery is part of the work.
+4. **A substantive repository documentation assessment is needed and representative reader tasks must be discovered, validated, or assessed together** → [Documentation assessment workflow](documentation-assessment.md).
+   - Use this route for broad documentation-quality assessment, navigation or authority problems, or deciding the smallest justified documentation response when reader/task discovery or multi-task validation is part of the work.
    - Do not route ordinary bounded documentation edits, known corrections or explicit drafting tasks through assessment merely because documentation is involved.
-   - If one concrete reader task is already known and no multi-task discovery is needed, use [Repository documentation assessment](../documentation/repository-assessment.md) as the proportionate single-task path.
+   - If one concrete reader task is already known and no multi-task discovery or validation is needed, use [Repository documentation assessment](../documentation/repository-assessment.md) as the proportionate single-task path.
 
 5. **Ordinary governed continuation** → [Autonomous progression](autonomous-progression.md).
    - Continue while current policy, evidence, scope and available capabilities safely determine the next action.

--- a/prompts/workflows/documentation-assessment.md
+++ b/prompts/workflows/documentation-assessment.md
@@ -1,0 +1,94 @@
+# Documentation assessment workflow
+
+## Purpose
+
+Run a governed, evidence-led repository documentation assessment when the right reader tasks still need to be discovered or validated before any documentation change is justified.
+
+## When to use
+
+Use for broad repository documentation assessment, navigation or authority problems, documentation-quality questions, or when the smallest justified response depends on discovering representative reader tasks. For one already-known reader task, prefer the narrower [Repository documentation assessment](../documentation/repository-assessment.md). Do not use this workflow merely because an already-bounded documentation edit or drafting task is involved.
+
+## Prompt
+
+```text
+Assess the documentation of <TARGET_REPOSITORY> using the Promptbook documentation-assessment route.
+
+Method authority
+
+Use `8ft0-ai/diataxis-for-ai-repos` release `v0.1.2`, pinned to exact commit `c1e1982dd448b3574bb7e14667363ba9db326c5c`, as the external assessment-method authority. The exact commit governs. Do not follow external `main` or silently move to a later release.
+
+Promptbook remains the governing workflow and authority layer. Repository-local instructions, explicit task authority, platform safety constraints and current target-repository evidence take precedence. Do not import a second IssueOps or governance lifecycle from the external method.
+
+Adoption level
+
+Use Level 2 task evidence by default for a substantive repository assessment. If one narrow reader task or documentation question is already known and can be assessed proportionately, use the existing Promptbook single-task assessment instead. Use Level 3 controls only when method evaluation, higher-risk execution, repository-local policy or a separately governed experiment actually requires them.
+
+Assessment setup
+
+1. Reconstruct the target repository identity and a sufficiently current pinned evidence state.
+2. Treat repository evidence as evidence, not complete truth.
+3. Distinguish Observation, Authority, Inference and Uncertainty for material conclusions.
+4. Identify evidence-supported reader groups. Do not invent personas from directory shape.
+5. Propose a small set of representative reader tasks based on real reader outcomes, not Diátaxis categories.
+6. Give each task a realistic starting context and answer-neutral completion condition.
+7. Identify command, network, credential, freshness, isolation or prerequisite constraints only where they materially affect that task.
+8. Identify protected decisions involving intent, policy, priority, ownership, rationale or disputed authority.
+9. Do not manufacture tasks merely to justify a documentation change. Retain and no-change are valid outcomes.
+
+Human task-set gate
+
+Before executing task walkthroughs, present one Promptbook decision capsule covering only the material owner judgements:
+
+DECISION_REQUIRED — Documentation assessment task set
+
+Recommended: ACCEPT
+
+ACCEPT — approve the proposed readers, tasks and bounded execution conditions
+CHANGE — revise the proposed assessment
+REJECT — stop this assessment
+
+The proposal must make clear the reader groups, representative tasks and priority, starting contexts, answer-neutral completion conditions, any material execution/freshness boundaries, and protected decisions. Do not require separate owner approval of Level-3 experimental bookkeeping when it is not material to the Level-2 task.
+
+After acceptance
+
+After an unambiguous accepted task set, refresh decision-critical state and continue without routine `proceed` confirmations through:
+
+1. approved task-path walkthroughs or execution;
+2. evidence recording with accurate primary results: Complete, Partial, Blocked or Not tested;
+3. classification of failures, retained paths and no-change outcomes;
+4. selection of the smallest sufficient response;
+5. a bounded remediation backlog where evidence justifies change;
+6. limitations and close-out.
+
+Preserve prerequisite, freshness and isolation checks only when the actual task depends on them. Stop rather than invent unavailable intent or authority.
+
+Remediation handoff
+
+Assessment does not create target-repository mutation authority.
+
+- If no change is justified, finish as COMPLETE.
+- If remediation is justified and implementation authority already exists under the target repository's governing task, return control to Promptbook's normal workflow router and continue only within that authority.
+- If remediation mutation is not yet authorised, present one bounded Promptbook decision capsule for the remediation scope. On acceptance, route to the normal Promptbook planning/implementation lifecycle.
+
+Do not create or invoke a parallel external governance lifecycle.
+
+Proportionality and no-route behaviour
+
+Use the lightest route that supports the decision. Do not route ordinary bounded documentation edits, known corrections or explicit drafting tasks through a new assessment. If repository evidence supports no material assessment need, record retain/no-change and finish. If the requested outcome is already an accepted implementation problem, route it to the normal governed engineering path instead of reassessing it.
+```
+
+## Inputs
+
+- `<TARGET_REPOSITORY>` — the repository whose documentation needs a substantive evidence-led assessment.
+
+## What it does
+
+Adapts the released Diátaxis assessment method into Promptbook's governed workflow model: Level 2 by default, one genuine human task-set gate, autonomous continuation after acceptance, and a clean handoff back to Promptbook for any separately authorised remediation.
+
+## Boundaries / limitations
+
+This workflow is assessment-only. It does not grant target-repository mutation, documentation drafting, release, deployment, credential or merge authority. It intentionally does not import external IssueOps, mandatory durable assessment publication, blanket evidence budgets, mutation-class machinery, blinded fixtures or independent-review experiments unless the actual governed task requires those controls.
+
+## Status
+
+`experimental`

--- a/prompts/workflows/documentation-assessment.md
+++ b/prompts/workflows/documentation-assessment.md
@@ -21,7 +21,7 @@ Promptbook remains the governing workflow and authority layer. Repository-local 
 
 Adoption level
 
-Use Level 2 task evidence by default for a substantive repository assessment. If one narrow reader task or documentation question is already known and can be assessed proportionately, use the existing Promptbook single-task assessment instead. Use Level 3 controls only when method evaluation, higher-risk execution, repository-local policy or a separately governed experiment actually requires them.
+Use Level 2 task evidence by default for a substantive repository assessment. If one narrow reader task or documentation question is already known and can be assessed proportionately, use the existing Promptbook Level 1 single-task assessment instead. Use Level 3 controls only when method evaluation, higher-risk execution, repository-local policy or a separately governed experiment actually requires them.
 
 Assessment setup
 

--- a/tests/test_validate_promptbook.py
+++ b/tests/test_validate_promptbook.py
@@ -75,6 +75,7 @@ class PromptbookValidationTests(unittest.TestCase):
 
         for target in (
             "autonomous-progression.md",
+            "documentation-assessment.md",
             "fresh-independent-review.md",
             "next-session-handover.md",
             "../engineering/plan-an-issue.md",
@@ -108,6 +109,50 @@ class PromptbookValidationTests(unittest.TestCase):
 
         for pattern in MODULE.PRIVATE_PATTERNS.values():
             self.assertNotIn(pattern, text)
+
+    def test_documentation_assessment_workflow_contract(self):
+        workflow = (
+            ROOT / "prompts" / "workflows" / "documentation-assessment.md"
+        ).read_text(encoding="utf-8")
+        workflow_lower = workflow.lower()
+        router = (ROOT / "prompts" / "workflows" / "README.md").read_text(encoding="utf-8")
+        router_lower = router.lower()
+        single = (
+            ROOT / "prompts" / "documentation" / "repository-assessment.md"
+        ).read_text(encoding="utf-8")
+        prompt_index = (ROOT / "prompts" / "README.md").read_text(encoding="utf-8")
+
+        self.assertIn("v0.1.2", workflow)
+        self.assertIn("c1e1982dd448b3574bb7e14667363ba9db326c5c", workflow)
+        self.assertIn("exact commit", workflow_lower)
+        self.assertIn("do not follow external `main`", workflow_lower)
+        self.assertIn("level 2", workflow_lower)
+        self.assertIn("level 1", workflow_lower)
+        self.assertIn("level 3", workflow_lower)
+        self.assertIn("DECISION_REQUIRED — Documentation assessment task set", workflow)
+        self.assertIn("Recommended: ACCEPT", workflow)
+        self.assertIn("ACCEPT — approve", workflow)
+        self.assertIn("CHANGE — revise", workflow)
+        self.assertIn("REJECT — stop", workflow)
+        self.assertIn("continue without routine `proceed` confirmations", workflow_lower)
+        self.assertIn("assessment does not create target-repository mutation authority", workflow_lower)
+        self.assertIn("normal promptbook planning/implementation lifecycle", workflow_lower)
+        self.assertIn("do not create or invoke a parallel external governance lifecycle", workflow_lower)
+        self.assertIn("issueops", workflow_lower)
+        self.assertIn("mandatory durable assessment publication", workflow_lower)
+        self.assertIn("mutation-class machinery", workflow_lower)
+
+        self.assertIn("documentation-assessment.md", router)
+        self.assertIn("representative reader tasks are not already known", router_lower)
+        self.assertIn("ordinary bounded documentation edits", router_lower)
+        self.assertIn("known corrections", router_lower)
+        self.assertIn("explicit drafting tasks", router_lower)
+        self.assertIn("../documentation/repository-assessment.md", router)
+        self.assertEqual(PUBLIC_COMMANDS, declared_commands(router, "Shorthand commands"))
+
+        self.assertIn("level-1/single-task", single.lower())
+        self.assertIn("../workflows/documentation-assessment.md", single)
+        self.assertIn("workflows/documentation-assessment.md", prompt_index)
 
     def test_single_maintainer_router_contract(self):
         text = (ROOT / "prompts" / "workflows" / "README.md").read_text(encoding="utf-8")

--- a/tests/test_validate_promptbook.py
+++ b/tests/test_validate_promptbook.py
@@ -143,7 +143,12 @@ class PromptbookValidationTests(unittest.TestCase):
         self.assertIn("mutation-class machinery", workflow_lower)
 
         self.assertIn("documentation-assessment.md", router)
-        self.assertIn("representative reader tasks are not already known", router_lower)
+        self.assertIn(
+            "representative reader tasks must be discovered, validated, or assessed together",
+            router_lower,
+        )
+        self.assertIn("reader/task discovery or multi-task validation", router_lower)
+        self.assertIn("no multi-task discovery or validation is needed", router_lower)
         self.assertIn("ordinary bounded documentation edits", router_lower)
         self.assertIn("known corrections", router_lower)
         self.assertIn("explicit drafting tasks", router_lower)


### PR DESCRIPTION
Closes #16 and #18 when merged.

## Governing contract

- Planning disposition: #16 comment `5309608415`
- Owner acceptance / implementation authority: #16 comment `5309617588`
- Fresh review blocking finding on prior head: Level-2 routing was too narrow for known multi-task assessments
- Bounded remediation issue: #18
- Required base/current `main`: `efc1639ebda0f84fd88dd821e1184b35c5628c0b`
- External method authority: `8ft0-ai/diataxis-for-ai-repos` `v0.1.2` at exact commit `c1e1982dd448b3574bb7e14667363ba9db326c5c`

## What changed

Exactly five authorised surfaces in the complete adoption candidate:

- add `prompts/workflows/documentation-assessment.md` as the experimental Level-2 adapter;
- route broad/evidence-led documentation assessment from `prompts/workflows/README.md` without adding a slash command;
- clarify `prompts/documentation/repository-assessment.md` as the proportionate Level-1/single-task path;
- expose the new workflow from `prompts/README.md`;
- add regression coverage in `tests/test_validate_promptbook.py`.

The adapter preserves one material human reader/task-set gate, resumes assessment without routine `proceed` confirmations after acceptance, and hands any separately authorised remediation back to Promptbook's normal lifecycle.

## Review remediation

Issue #18 remediates the prior fresh-review blocker with exactly two files changed from reviewed head `6c70b82c356dd5b60f6a26453e449c991e16fcc7`:

- `prompts/workflows/README.md` — Level 2 now covers substantive multi-task assessment when representative tasks must be discovered, validated, or assessed together; Level 1 remains the one-known-task path when no multi-task discovery or validation is needed.
- `tests/test_validate_promptbook.py` — regression coverage now protects that distinction.

No other file changed in the remediation.

## Explicit exclusions

No root README, `AGENTS.md`, `BOOTSTRAP`, project-bootstrap guide, command vocabulary, validator script, external repository, target repository, settings, release or automation changes.

No second IssueOps/governance lifecycle is introduced. Level-3 experimental machinery is not imported by default.

## Final candidate and validation

- exact head: `a44eacfd6e42341e7856446fa443622a155e0c98`
- exact base/current required `main`: `efc1639ebda0f84fd88dd821e1184b35c5628c0b`
- complete changed-file set: exactly the original five authorised surfaces
- remediation delta from prior reviewed head: exactly two authorised files
- exact-head validation: run `31973277496` / job `95228902919` — **success**
- public prompt contract validation: success
- validator tests: success

Fresh independent substantive review of this exact final head is required before merge. This remediation context must not self-certify that gate.