### PR TITLE
Make continuation policy a router-owned postcondition

### DIFF
--- a/prompts/engineering/implement-an-approved-issue.md
+++ b/prompts/engineering/implement-an-approved-issue.md
@@ -29,7 +29,9 @@ Before declaring completion:
 
 Return a concise implementation record: outcome delivered, principal changes, acceptance-criterion coverage, validation and results, justified plan deviations, and remaining limitations.
 
-Do not merge, deploy, release, or broaden scope unless that action is already authorised separately.
+That implementation record is the workflow record, not a routed terminal state. When this workflow is invoked through the workflow router, return control to the router after recording it so the router can apply the effective continuation mode to the next governed gate. If required independent review is the next gate and this context authored or materially shaped the candidate, preserve the fresh-context boundary rather than reviewing the candidate here; a durable target may be handed off as `Next chat: /review <APPROVED_TASK>` when that target is sufficient for reconstruction.
+
+Do not merge, deploy, release, or broaden scope unless that action is already authorised separately. Continuation metadata never creates that authority.
 ```
 
 ## Inputs
@@ -39,11 +41,11 @@ Do not merge, deploy, release, or broaden scope unless that action is already au
 
 ## What it does
 
-Keeps implementation tied to the approved outcome, makes validation part of completion, and forces plan drift to be reconciled before speculative code changes.
+Keeps implementation tied to the approved outcome, makes validation part of completion, and forces plan drift to be reconciled before speculative code changes. When routed, the implementation record returns control to the governing workflow instead of accidentally ending the broader objective.
 
 ## Boundaries / limitations
 
-This prompt does not grant repository mutation, merge, deployment, credential, or production authority. The receiving environment must already have those capabilities and permissions where needed.
+This prompt does not grant repository mutation, merge, deployment, credential, or production authority. The receiving environment must already have those capabilities and permissions where needed. A required fresh independent review remains a hard boundary after this context authors or materially shapes the candidate.
 
 ## Status
 

--- a/prompts/engineering/plan-an-issue.md
+++ b/prompts/engineering/plan-an-issue.md
@@ -29,6 +29,8 @@ Otherwise produce the smallest sufficient implementation plan covering:
 - whether the work is one coherent change or should be decomposed.
 
 Do not begin implementation while planning. End with one disposition: READY FOR IMPLEMENTATION, BLOCKED PENDING DECISION/EVIDENCE, or DECOMPOSE BEFORE IMPLEMENTATION.
+
+That disposition is the planning record. When this workflow is invoked through the workflow router, return control to the router after recording the disposition; do not treat `READY FOR IMPLEMENTATION` or another local planning disposition as a conversational terminal state. The router's effective continuation mode determines whether to enter the next authorised workflow, suggest the smallest safe next invocation, or stop after the requested deliverable. The planning record does not itself grant implementation or repository-mutation authority.
 ```
 
 ## Inputs
@@ -37,11 +39,11 @@ Do not begin implementation while planning. End with one disposition: READY FOR 
 
 ## What it does
 
-Forces the plan to be grounded in current repository evidence and ties each acceptance criterion to both work and validation rather than producing a generic checklist.
+Forces the plan to be grounded in current repository evidence and ties each acceptance criterion to both work and validation rather than producing a generic checklist. When routed as part of a broader governed objective, it leaves continuation to the router rather than turning the planning disposition into an accidental stop.
 
 ## Boundaries / limitations
 
-The prompt does not resolve genuinely missing product or authority decisions. It assumes the assistant can inspect the relevant repository or that the user supplies equivalent evidence.
+The prompt does not resolve genuinely missing product or authority decisions. It assumes the assistant can inspect the relevant repository or that the user supplies equivalent evidence. A planning disposition never supplies implementation authority.
 
 ## Status
 

--- a/prompts/engineering/remediate-review-findings.md
+++ b/prompts/engineering/remediate-review-findings.md
@@ -24,7 +24,9 @@ Implement the bounded corrections, add or adjust regression coverage that would 
 
 Return a remediation record mapping each blocking finding to the change and proof that resolves it. Clearly identify any finding that still requires a separate decision rather than pretending remediation is complete.
 
-Preserve any required independent re-review boundary; do not present author-side remediation as fresh approval evidence.
+That remediation record is the workflow record, not a routed terminal state. When this workflow is invoked through the workflow router, return control to the router after recording it so the router can apply the effective continuation mode.
+
+Preserve any required independent re-review boundary; do not present author-side remediation as fresh approval evidence. If this context changed the candidate and independent re-review is required, do not enter that review here. Treat the re-review as a hard fresh-context boundary and, when the durable target is sufficient for reconstruction, hand it off as `Next chat: /review <REVIEWED_CANDIDATE>`. That navigation is not review or merge authority.
 ```
 
 ## Inputs
@@ -33,11 +35,11 @@ Preserve any required independent re-review boundary; do not present author-side
 
 ## What it does
 
-Keeps remediation narrow, makes review findings traceable to regression evidence, and prevents a repair cycle from becoming an unbounded redesign.
+Keeps remediation narrow, makes review findings traceable to regression evidence, and prevents a repair cycle from becoming an unbounded redesign. When routed, it returns the remediation record to the governing workflow while preserving the mandatory fresh-context boundary for re-review of a candidate changed in this context.
 
 ## Boundaries / limitations
 
-Use only where the expected correction is objectively bounded by existing requirements. Materially new architecture, authority, security, product, or scope decisions should be resolved separately.
+Use only where the expected correction is objectively bounded by existing requirements. Materially new architecture, authority, security, product, or scope decisions should be resolved separately. Author-side remediation cannot substitute for fresh independent review when that gate is required.
 
 ## Status
 

--- a/prompts/workflows/README.md
+++ b/prompts/workflows/README.md
@@ -36,6 +36,39 @@ When a user message begins with one of these commands, treat it as a concise int
 
 Keep the command set small. Prefer natural-language qualifiers over inventing flags or a larger command grammar.
 
+## Continuation policy
+
+Continuation mode is a preference layer owned by this router. Apply it only after all hard governance constraints have been satisfied. A specialised workflow's local output, disposition, implementation record, remediation record, or other workflow record is not permission to end a routed objective in an unexplained intermediate state.
+
+The supported continuation modes are:
+
+- `auto` — enter the next safely authorised and executable same-context workflow automatically. `auto` cannot cross a required fresh-context boundary or another hard stop.
+- `suggest` — do not enter the next workflow in this invocation. When a broader objective remains active, emit the smallest safely determined `Next:` or `Next chat:` navigation.
+- `stop` — treat the explicitly requested deliverable as the end of this invocation and do not enter another workflow. `stop` does not suppress required terminal-state classification. When a broader governed objective is already active and its next invocation is safely determined, router postconditions may still expose that navigation unless the user explicitly requested no continuation guidance.
+
+Hard constraints always win over continuation preferences. These include platform safety, explicit task authority, repository-local mandatory policy, fresh-independence requirements, required validation, current authoritative evidence, accepted governance records that require a stop or hand-off, and any other mandatory control established by the governing task. A continuation preference cannot create or bypass mutation, merge, deploy, credential, production, acceptance, review, validation, security, or scope authority.
+
+Within the remaining continuation-preference layer, resolve the effective mode in this order:
+
+1. explicit current-user qualifier, such as `review only`, `continue afterwards`, or `/go until ...`;
+2. repository/task-specific continuation preference, when one exists and is not already a mandatory hard constraint;
+3. managed Project continuation preference, when one exists;
+4. Promptbook command default.
+
+The command defaults are:
+
+| Command | Default continuation mode |
+| --- | --- |
+| `/go` | `auto` |
+| `/implement` | `auto` |
+| `/fix` | `auto` |
+| `/review` | `suggest` |
+| `/plan` | `suggest` |
+| `/status` | `stop` |
+| `/handoff` | `stop` |
+
+A lower-precedence preference may choose only among actions already permitted by higher-precedence constraints. Navigation emitted under `suggest` or `stop` is navigation metadata only and never supplies authority to the receiving invocation.
+
 ## Routing
 
 Before routing, inspect the current conversation and the authoritative repository or task state needed for the next decision. Stale summaries are navigation aids, not authority. Select exactly one primary workflow and apply it immediately; routing itself is not a stop point.
@@ -174,7 +207,7 @@ Fail closed when the next invocation is not safely determined. `DECISION_REQUIRE
 - When `EXTERNAL_REQUIRED` applies, reduce the human role to performing one explicit external action and returning its requested evidence. Scripts or command sequences presented as executable must be complete and self-contained for the stated operation; never expose secret values or present a truncated fragment as the handoff. If an equivalent valid external handoff is already durable and decision-critical state has not materially changed, reuse it after refreshing stale-able guards instead of repeating capability discovery. A capability limitation with sufficient authority is not itself `DECISION_REQUIRED`; if the safe external procedure cannot be determined completely, surface the real decision or blocker instead of a vague handoff.
 - Treat an unambiguous returned external observation such as `PASS` or `FAIL <material defect>` only as evidence for the named check, never as new mutation, merge, production, close, or acceptance authority. After such evidence returns, resume the governing workflow automatically when existing authority already determines the next action; before any consequential mutation, refresh only the decision-critical state capable of invalidating that evidence or action. Do not delegate already-established machine-verifiable checks to the human. On `FAIL`, preserve fail-closed behaviour and route the defect through the existing governed scope and authority rather than treating the observation as acceptance.
 - When `DECISION_REQUIRED` applies, present the decision capsule instead of making the user copy an approval phrase or repository identifier. Once an unambiguous `ACCEPT` or `CHOOSE` response is safely bound and refreshed, continue any already-authorised routine work without another `proceed` confirmation.
-- Output or deliverable constraints inside a selected workflow apply to that workflow's record. They do not override this router's continuation semantics unless the user or governing task explicitly requested that workflow result as the final deliverable.
+- Output or deliverable constraints inside a selected workflow apply to that workflow's record. They do not override this router's continuation semantics. After recording the local workflow result, return control to the router and apply the effective continuation mode unless a higher-precedence hard constraint or explicit current-user qualifier requires stopping.
 - A fresh review disposition does not itself create mutation authority. When fresh review is an intermediate gate under this router, record its single clear disposition and concise rationale, then return control to the governing workflow. If `CHANGES REQUIRED` identifies a bounded defect whose minimum-safe remediation is objectively determined and already authorised, continue through autonomous progression to remediate and validate it without another routine approval. Because that context then authored the changed candidate, route the new candidate to a genuinely fresh review context before any gate requiring independence. A single-maintainer project may use the same GitHub identity in that new fresh context. If the disposition is `APPROVED`, continue already-authorised merge, verification and close-out work rather than stopping at review completion or at a platform refusal to record formal self-approval, unless repository-local rules make that approval status mandatory.
 - A requested handover is terminal for the current deliverable; execution belongs to the receiving context.
 - Do not invent adjacent work after the governed objective is complete.

--- a/prompts/workflows/autonomous-progression.md
+++ b/prompts/workflows/autonomous-progression.md
@@ -15,6 +15,15 @@ Progress <TASK_OR_OBJECTIVE> as far as safely possible with minimal human interv
 
 Treat repository-local instructions, explicit task authority, accepted plans/decisions, current evidence, and platform safety constraints as authoritative.
 
+Before entering another workflow, resolve the effective continuation mode from the workflow router. Apply all hard governance constraints first; continuation mode is only a preference among actions already permitted by those constraints. It never creates mutation, merge, deploy, credential, production, acceptance, review, validation, security, or scope authority.
+
+Use the router-defined modes as follows:
+- `auto` — enter the next safely authorised and executable same-context workflow automatically;
+- `suggest` — do not enter the next workflow; when a broader objective remains active, emit the smallest safely determined `Next:` / `Next chat:` navigation;
+- `stop` — end after the explicitly requested deliverable without suppressing any required terminal-state classification; when a broader objective is already active, expose safely determined navigation unless the user explicitly requested no continuation guidance.
+
+A specialised workflow's local disposition or record is a workflow record, not a conversational terminal state. After recording it, return control to the router and apply the effective continuation mode unless a higher-precedence hard constraint requires a boundary.
+
 Continue autonomously while the next action is:
 1. inside the current objective and scope;
 2. supported by sufficiently current evidence;
@@ -28,6 +37,8 @@ Escalate only as one of these states:
 - DECISION_REQUIRED — a genuine human judgement/authority decision is needed, such as material scope/outcome/architecture change, permission broadening, security weakening, destructive/production action, material cost, or acceptance of a known failed control;
 - BLOCKED — no safe action, external handoff, or concrete human decision can resolve the condition now;
 - COMPLETE — the governed objective is genuinely finished and required verification/close-out is done.
+
+Fresh independence, missing authority, failed or missing required validation, materially changed accepted proposals, repository/task policy requiring an explicit stop, and the terminal states above are hard boundaries. `auto` must not cross them merely to preserve momentum.
 
 When EXTERNAL_REQUIRED applies, do not merely name the missing capability, credential, receiving context, or external tool. State the one concrete external action the human must perform and provide the smallest complete procedure in the same response. Use a complete copy/paste script or exact commands when command-line execution is appropriate; otherwise give exact browser or UI steps, or another concrete step-by-step procedure. Include material prerequisites, immutable identities, authority/safety guards, fail-closed checks, cleanup/revocation/restore steps, and prohibited actions. State the exact evidence or output the human should return so governed continuation can resume without reconstructing the prior conversation. Do not make the human ask how to perform the external action.
 
@@ -49,7 +60,7 @@ REJECT rejects only the presented proposal or choice; it does not implicitly clo
 
 When a bounded defect has an objectively determined minimum-safe remediation inside the existing contract, remediate and validate it without asking for another routine approval. Do not invent adjacent work merely to keep moving.
 
-Before ending, state why stopping is necessary. If another requested workflow intentionally stops while a broader governed objective remains active and a safe next invocation is durably reconstructible, append the smallest `Next:` or `Next chat:` navigation without executing it in the current context. Prefer the governing objective for `/go` when an intermediate artefact is not the complete lifecycle target, and use `/fix` only when bounded remediation is already authorised. If EXTERNAL_REQUIRED is human-operated external execution, include the explicit executable external action and the evidence to return; a slash command is not a substitute. If DECISION_REQUIRED applies, use the decision capsule and do not add a command that bypasses it. If BLOCKED applies, do not manufacture `/go`, `/fix`, or `/review` merely to offer motion. If COMPLETE applies, state that no further action is required. If none of EXTERNAL_REQUIRED, DECISION_REQUIRED, BLOCKED, or COMPLETE applies, continue the next authorised action.
+Before ending, state why stopping is necessary. If another requested workflow intentionally stops while a broader governed objective remains active and a safe next invocation is durably reconstructible, append the smallest `Next:` or `Next chat:` navigation without executing it in the current context. Prefer the governing objective for `/go` when an intermediate artefact is not the complete lifecycle target, and use `/fix` only when bounded remediation is already authorised. If EXTERNAL_REQUIRED is human-operated external execution, include the explicit executable external action and the evidence to return; a slash command is not a substitute. If DECISION_REQUIRED applies, use the decision capsule and do not add a command that bypasses it. If BLOCKED applies, do not manufacture `/go`, `/fix`, or `/review` merely to offer motion. If COMPLETE applies, state that no further action is required. If none of EXTERNAL_REQUIRED, DECISION_REQUIRED, BLOCKED, or COMPLETE applies, apply the effective continuation mode: under `auto`, continue the next authorised same-context action; under `suggest`, emit the smallest safe navigation without entering the next workflow; under `stop`, end the requested deliverable while preserving any router-required navigation.
 ```
 
 ## Inputs
@@ -58,11 +69,11 @@ Before ending, state why stopping is necessary. If another requested workflow in
 
 ## What it does
 
-Separates genuine human decisions and capability boundaries from ordinary lifecycle status, reducing repeated “proceed?” interactions while retaining fail-closed behaviour. When a capability boundary genuinely requires human-operated external execution, it reduces the human role to performing one explicit, complete action and returning the requested evidence rather than working out how to continue. A genuine context-transfer boundary may instead use a minimal reconstructible next invocation without weakening the external-execution contract. Returned external evidence is scoped to the named check and governed work resumes automatically when existing authority already determines what follows. When a human decision is genuinely required, it presents a compact device-neutral decision capsule and resumes governed autonomous progression after an unambiguous bounded response.
+Separates genuine human decisions and capability boundaries from ordinary lifecycle status, reducing repeated “proceed?” interactions while retaining fail-closed behaviour. It applies the router-owned continuation preference only after hard constraints have been satisfied, so local workflow records do not accidentally become terminal states and `auto` cannot manufacture authority. When a capability boundary genuinely requires human-operated external execution, it reduces the human role to performing one explicit, complete action and returning the requested evidence rather than working out how to continue. A genuine context-transfer boundary may instead use a minimal reconstructible next invocation without weakening the external-execution contract. Returned external evidence is scoped to the named check and governed work resumes automatically when existing authority already determines what follows. When a human decision is genuinely required, it presents a compact device-neutral decision capsule and resumes governed autonomous progression after an unambiguous bounded response.
 
 ## Boundaries / limitations
 
-This prompt never overrides repository-local policy or grants credentials, production authority, destructive-action authority, or permission to widen scope. Autonomy is limited to actions already justified by the governing objective and evidence. Suggested next invocations are navigation only. An external handoff must not expose secret values, invent an unsafe procedure, or substitute shorthand navigation for a complete human-operated external action merely to avoid a stop. Returned observations are evidence, not new authority. Short natural-language or voice responses are authority only when their decision referent is unambiguous; materially changed proposals must be re-presented rather than inheriting stale acceptance.
+This prompt never overrides repository-local policy or grants credentials, production authority, destructive-action authority, or permission to widen scope. Autonomy is limited to actions already justified by the governing objective and evidence. Continuation mode is a preference, never authority. Suggested next invocations are navigation only. An external handoff must not expose secret values, invent an unsafe procedure, or substitute shorthand navigation for a complete human-operated external action merely to avoid a stop. Returned observations are evidence, not new authority. Short natural-language or voice responses are authority only when their decision referent is unambiguous; materially changed proposals must be re-presented rather than inheriting stale acceptance.
 
 ## Status
 

--- a/tests/test_next_invocation_guidance.py
+++ b/tests/test_next_invocation_guidance.py
@@ -5,6 +5,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOWS = ROOT / "prompts" / "workflows"
 ENGINEERING = ROOT / "prompts" / "engineering"
+DOCUMENTATION = ROOT / "prompts" / "documentation"
 
 
 class NextInvocationGuidanceTests(unittest.TestCase):
@@ -24,6 +25,10 @@ class NextInvocationGuidanceTests(unittest.TestCase):
             encoding="utf-8"
         )
         cls.autonomous_lower = cls.autonomous.lower()
+        cls.documentation_assessment = (
+            WORKFLOWS / "documentation-assessment.md"
+        ).read_text(encoding="utf-8")
+        cls.documentation_assessment_lower = cls.documentation_assessment.lower()
         cls.plan = (ENGINEERING / "plan-an-issue.md").read_text(encoding="utf-8")
         cls.plan_lower = cls.plan.lower()
         cls.implement = (ENGINEERING / "implement-an-approved-issue.md").read_text(
@@ -34,6 +39,10 @@ class NextInvocationGuidanceTests(unittest.TestCase):
             encoding="utf-8"
         )
         cls.remediate_lower = cls.remediate.lower()
+        cls.repository_assessment = (
+            DOCUMENTATION / "repository-assessment.md"
+        ).read_text(encoding="utf-8")
+        cls.repository_assessment_lower = cls.repository_assessment.lower()
 
     def test_router_defines_navigation_not_authority(self):
         self.assertIn("## Next-invocation guidance", self.router)
@@ -135,11 +144,46 @@ class NextInvocationGuidanceTests(unittest.TestCase):
                 "first distinguish the handover type",
                 "directly copyable as the next prompt",
             ),
+            "documentation assessment": (
+                self.documentation_assessment_lower,
+                "assessment does not create target-repository mutation authority",
+                "return control to promptbook's normal workflow router",
+            ),
+            "repository assessment": (
+                self.repository_assessment_lower,
+                "return one primary result: complete, partial, blocked, or not tested",
+                "smallest sufficient next action",
+            ),
         }
         for name, (text, record_marker, composition_marker) in matrix.items():
             with self.subTest(workflow=name):
                 self.assertIn(record_marker, text)
                 self.assertIn(composition_marker, text)
+
+    def test_documentation_assessment_paths_obey_router_postcondition(self):
+        self.assertIn(
+            "[documentation assessment workflow](documentation-assessment.md)",
+            self.router_lower,
+        )
+        self.assertIn(
+            "[repository documentation assessment](../documentation/repository-assessment.md)",
+            self.router_lower,
+        )
+        self.assertIn(
+            "return control to promptbook's normal workflow router",
+            self.documentation_assessment_lower,
+        )
+        self.assertIn(
+            "return one primary result: complete, partial, blocked, or not tested",
+            self.repository_assessment_lower,
+        )
+        self.assertIn(
+            "a specialised workflow's local output, disposition, implementation record, "
+            "remediation record, or other workflow record is not permission to end a "
+            "routed objective",
+            self.router_lower,
+        )
+        self.assertIn("apply the effective continuation mode", self.router_lower)
 
     def test_plan_and_go_positive_composition(self):
         self.assertIn("| `/plan` | `suggest` |", self.router)

--- a/tests/test_next_invocation_guidance.py
+++ b/tests/test_next_invocation_guidance.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOWS = ROOT / "prompts" / "workflows"
+ENGINEERING = ROOT / "prompts" / "engineering"
 
 
 class NextInvocationGuidanceTests(unittest.TestCase):
@@ -23,6 +24,16 @@ class NextInvocationGuidanceTests(unittest.TestCase):
             encoding="utf-8"
         )
         cls.autonomous_lower = cls.autonomous.lower()
+        cls.plan = (ENGINEERING / "plan-an-issue.md").read_text(encoding="utf-8")
+        cls.plan_lower = cls.plan.lower()
+        cls.implement = (ENGINEERING / "implement-an-approved-issue.md").read_text(
+            encoding="utf-8"
+        )
+        cls.implement_lower = cls.implement.lower()
+        cls.remediate = (ENGINEERING / "remediate-review-findings.md").read_text(
+            encoding="utf-8"
+        )
+        cls.remediate_lower = cls.remediate.lower()
 
     def test_router_defines_navigation_not_authority(self):
         self.assertIn("## Next-invocation guidance", self.router)
@@ -30,6 +41,151 @@ class NextInvocationGuidanceTests(unittest.TestCase):
         self.assertIn("navigation metadata only", self.router_lower)
         self.assertIn("does not grant approval", self.router_lower)
         self.assertIn("receiving context must reconstruct", self.router_lower)
+
+    def test_router_owns_continuation_policy(self):
+        self.assertIn("## Continuation policy", self.router)
+        self.assertIn(
+            "continuation mode is a preference layer owned by this router",
+            self.router_lower,
+        )
+        self.assertIn(
+            "a specialised workflow's local output, disposition, implementation record, "
+            "remediation record, or other workflow record is not permission to end a "
+            "routed objective",
+            self.router_lower,
+        )
+        for mode in ("`auto`", "`suggest`", "`stop`"):
+            self.assertIn(mode, self.router)
+        self.assertIn("hard constraints always win over continuation preferences", self.router_lower)
+        self.assertIn("a continuation preference cannot create or bypass", self.router_lower)
+        self.assertIn("navigation emitted under `suggest` or `stop`", self.router_lower)
+        self.assertIn("never supplies authority to the receiving invocation", self.router_lower)
+
+    def test_command_continuation_defaults_are_explicit(self):
+        expected = {
+            "/go": "auto",
+            "/implement": "auto",
+            "/fix": "auto",
+            "/review": "suggest",
+            "/plan": "suggest",
+            "/status": "stop",
+            "/handoff": "stop",
+        }
+        for command, mode in expected.items():
+            self.assertIn(f"| `{command}` | `{mode}` |", self.router)
+
+    def test_continuation_precedence_is_fail_closed(self):
+        ordered_markers = [
+            "explicit current-user qualifier",
+            "repository/task-specific continuation preference",
+            "managed project continuation preference",
+            "promptbook command default",
+        ]
+        positions = [self.router_lower.index(marker) for marker in ordered_markers]
+        self.assertEqual(sorted(positions), positions)
+        for hard_constraint in (
+            "platform safety",
+            "explicit task authority",
+            "repository-local mandatory policy",
+            "fresh-independence requirements",
+            "required validation",
+            "current authoritative evidence",
+            "accepted governance records that require a stop or hand-off",
+        ):
+            self.assertIn(hard_constraint, self.router_lower)
+        self.assertIn(
+            "a lower-precedence preference may choose only among actions already permitted",
+            self.router_lower,
+        )
+
+    def test_autonomous_progression_applies_effective_mode(self):
+        self.assertIn("resolve the effective continuation mode from the workflow router", self.autonomous_lower)
+        self.assertIn("apply all hard governance constraints first", self.autonomous_lower)
+        self.assertIn("continuation mode is only a preference", self.autonomous_lower)
+        self.assertIn("a specialised workflow's local disposition or record is a workflow record", self.autonomous_lower)
+        self.assertIn("return control to the router", self.autonomous_lower)
+        self.assertIn("under `auto`, continue the next authorised same-context action", self.autonomous_lower)
+        self.assertIn("under `suggest`, emit the smallest safe navigation", self.autonomous_lower)
+        self.assertIn("under `stop`, end the requested deliverable", self.autonomous_lower)
+
+    def test_router_reachable_specialised_workflow_matrix(self):
+        matrix = {
+            "plan": (
+                self.plan_lower,
+                "that disposition is the planning record",
+                "return control to the router",
+            ),
+            "implement": (
+                self.implement_lower,
+                "that implementation record is the workflow record",
+                "return control to the router",
+            ),
+            "remediate": (
+                self.remediate_lower,
+                "that remediation record is the workflow record",
+                "return control to the router",
+            ),
+            "fresh review": (
+                self.fresh_lower,
+                "single disposition is the review record",
+                "return control to that workflow",
+            ),
+            "handover": (
+                self.handover_lower,
+                "first distinguish the handover type",
+                "directly copyable as the next prompt",
+            ),
+        }
+        for name, (text, record_marker, composition_marker) in matrix.items():
+            with self.subTest(workflow=name):
+                self.assertIn(record_marker, text)
+                self.assertIn(composition_marker, text)
+
+    def test_plan_and_go_positive_composition(self):
+        self.assertIn("| `/plan` | `suggest` |", self.router)
+        self.assertIn("that disposition is the planning record", self.plan_lower)
+        self.assertIn("does not itself grant implementation", self.plan_lower)
+        self.assertIn("| `/go` | `auto` |", self.router)
+        self.assertIn("not permission to end a routed objective", self.router_lower)
+        self.assertIn("enter the next safely authorised and executable same-context workflow", self.router_lower)
+
+    def test_implementation_and_fix_preserve_fresh_review_boundary(self):
+        self.assertIn("required independent review is the next gate", self.implement_lower)
+        self.assertIn("preserve the fresh-context boundary", self.implement_lower)
+        self.assertIn("next chat: /review <approved_task>", self.implement_lower)
+        self.assertIn("| `/fix` | `auto` |", self.router)
+        self.assertIn("independent re-review is required", self.remediate_lower)
+        self.assertIn("hard fresh-context boundary", self.remediate_lower)
+        self.assertIn("next chat: /review <reviewed_candidate>", self.remediate_lower)
+
+    def test_review_default_and_explicit_override_are_composable(self):
+        self.assertIn("| `/review` | `suggest` |", self.router)
+        self.assertIn("explicitly requested as the final deliverable", self.fresh_lower)
+        self.assertIn("append one minimal `next:` invocation", self.fresh_lower)
+        self.assertIn("continue afterwards", self.router_lower)
+        self.assertIn("explicit current-user qualifier", self.router_lower)
+        self.assertIn("return control to that workflow", self.fresh_lower)
+
+    def test_auto_cannot_bypass_hard_boundaries(self):
+        for boundary in (
+            "fresh independence",
+            "missing authority",
+            "failed or missing required validation",
+            "materially changed accepted proposals",
+            "repository/task policy requiring an explicit stop",
+        ):
+            self.assertIn(boundary, self.autonomous_lower)
+        self.assertIn("`auto` must not cross them", self.autonomous_lower)
+        for terminal_state in (
+            "EXTERNAL_REQUIRED",
+            "DECISION_REQUIRED",
+            "BLOCKED",
+            "COMPLETE",
+        ):
+            self.assertIn(terminal_state, self.autonomous)
+        self.assertIn("human-operated external execution", self.handover_lower)
+        self.assertIn("slash command is not a substitute", self.autonomous_lower)
+        self.assertIn("does not create new mutation, merge, production, close, or acceptance authority", self.autonomous_lower)
 
     def test_fresh_context_can_use_minimal_review_invocation(self):
         self.assertIn("Next chat:", self.router)


### PR DESCRIPTION
Closes #35

## Summary

- make continuation mode (`auto | suggest | stop`) a router-owned preference applied only after hard governance constraints;
- define command defaults and continuation-preference precedence without changing the public shorthand vocabulary;
- return planning, implementation, and remediation records to the router instead of allowing local records to become accidental terminal states;
- preserve fresh-review, authority, validation, external-execution, decision, blocker, and completion boundaries;
- expand `test_next_invocation_guidance.py` across router-reachable specialised workflows, including unchanged fresh-review and handover contracts.

## Governing plan

Issue #35 comment `5384215226`.

Planning/base `main`: `5fb887aeb03b78a584fac5201e24bcc9fd74e100`.

## Scope

Changed exactly:

- `prompts/workflows/README.md`
- `prompts/workflows/autonomous-progression.md`
- `prompts/engineering/plan-an-issue.md`
- `prompts/engineering/implement-an-approved-issue.md`
- `prompts/engineering/remediate-review-findings.md`
- `tests/test_next_invocation_guidance.py`

No root README/bootstrap/AGENTS changes and no persistent Project/Watchtower state changes.

## Validation

Required repository validation is provided by the PR workflow:

```bash
python scripts/validate_promptbook.py
python -m unittest discover -s tests -p 'test_*.py' -v
```

The exact PR-head CI result is the authoritative validation evidence for the candidate.

## Review boundary

This context authored the candidate and is not fresh for its required substantive review. After exact-head validation succeeds, route the PR to a genuinely fresh context for independent review.