### PR TITLE
Extend resolved agent run context to /fix

### DIFF
--- a/prompts/engineering/remediate-review-findings.md
+++ b/prompts/engineering/remediate-review-findings.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Turn blocking review findings into the minimum safe correction without reopening unrelated design work.
+Turn blocking review findings into the minimum safe correction without reopening unrelated design work, using explicit reconstructable mutation authority rather than tool availability or remembered conversation state.
 
 ## When to use
 
@@ -13,16 +13,41 @@ Use after a substantive review has identified concrete defects and the existing 
 ```text
 Remediate the blocking findings on <REVIEWED_CANDIDATE>.
 
-First re-read the exact findings, the governing task/design, and the current candidate. Classify each finding as:
+First re-read the exact findings, the governing task/design, the current candidate, applicable repository instructions, and current authority. Before substantive mutation, resolve the `/fix` Resolved Agent Run Context defined by `prompts/workflows/resolved-agent-run-context.md` from current authoritative inputs rather than conversation memory.
+
+Bind the run context to the repository/work item, exact starting candidate identity, authority sources, instruction provenance, bounded remediation scope, effective and prohibited capabilities, owner-decision boundaries, required validation, and required evidence. Treat the context as ephemeral derived execution state, not as a new authority source.
+
+Immediately before the first material write, refresh the starting candidate identity. If it moved, invalidate the stale candidate-specific context and re-resolve before applying findings to unexpected bytes.
+
+Classify each finding as:
 - valid and bounded by the existing contract;
 - invalid or already resolved by current evidence; or
-- requiring a genuinely new product, architecture, authority, or scope decision.
+- requiring a genuinely new product, architecture, authority, security, or scope decision.
 
 For every valid bounded finding, derive the smallest safe correction. Do not broaden scope, redesign adjacent components, weaken validation, or treat review suggestions as requirements unless the governing contract makes them necessary.
 
-Implement the bounded corrections, add or adjust regression coverage that would have caught the defect, run the relevant validation, and inspect the complete resulting diff for accidental scope expansion.
+Before each material action, apply the `/fix` action gateway and classify the action as:
+- `ALLOW` — current authoritative sources permit the action within the resolved remediation scope and `/fix` operation ceiling;
+- `REQUIRE OWNER / SEPARATE AUTHORITY` — the action is outside the resolved remediation scope or needs missing product, architecture, security, scope, owner, or other separate authority;
+- `FORBID` — higher-precedence authority or the `/fix` operation ceiling prohibits the action under this `/fix` authority.
 
-Return a remediation record mapping each blocking finding to the change and proof that resolves it. Clearly identify any finding that still requires a separate decision rather than pretending remediation is complete.
+Missing or ambiguous authority never defaults to `ALLOW`. Keep authority classification separate from execution feasibility: a technically available tool never grants authority, while an `ALLOW` action whose required execution capability is unavailable follows the governing router's capability/external-action boundary without inventing a new owner decision.
+
+Execute only `ALLOW` actions that are actually available. Implement the bounded corrections, add or adjust regression coverage that would have caught the defect, run the relevant required validation, and inspect the complete resulting diff for accidental scope expansion. If unexpected external candidate movement is detected during remediation, fail closed and reconcile/re-resolve before continuing.
+
+Treat remediation as an immutable candidate transition: starting candidate A plus authorised bounded remediation produces candidate B. Once bytes change, candidate-A-specific review and validation do not silently transfer to B. Bind the resulting validation and evidence to B's exact immutable identity.
+
+Return a remediation record reconstructable as:
+- governing finding/remediation authority;
+- starting candidate identity;
+- bounded implementation delta;
+- resulting candidate identity;
+- validation/evidence bound to the resulting candidate;
+- any `REQUIRE OWNER / SEPARATE AUTHORITY` or `FORBID` boundaries encountered;
+- any authorised action that could not execute because of a capability boundary;
+- remaining boundaries and next governed state.
+
+Classify evidence honestly as `STATIC`, `EXECUTED`, or `DURABLE` according to the Resolved Agent Run Context contract. Do not imply execution occurred where only static reasoning was performed. Clearly identify any finding that still requires a separate decision rather than pretending remediation is complete.
 
 That remediation record is the workflow record, not a routed terminal state. When this workflow is invoked through the workflow router, return control to the router after recording it so the router can apply the effective continuation mode.
 
@@ -35,11 +60,15 @@ Preserve any required independent re-review boundary; do not present author-side
 
 ## What it does
 
-Keeps remediation narrow, makes review findings traceable to regression evidence, and prevents a repair cycle from becoming an unbounded redesign. When routed, it returns the remediation record to the governing workflow while preserving the mandatory fresh-context boundary for re-review of a candidate changed in this context.
+Keeps remediation narrow, makes mutation authority explicit, classifies material actions before execution, makes review findings traceable to regression evidence, and prevents a repair cycle from becoming an unbounded redesign. It binds remediation to starting candidate A and the resulting validation/evidence to candidate B, preventing candidate-specific review or validation from silently carrying across changed bytes.
+
+When routed, it returns the remediation record to the governing workflow while preserving the mandatory fresh-context boundary for re-review of a candidate changed in this context.
 
 ## Boundaries / limitations
 
-Use only where the expected correction is objectively bounded by existing requirements. Materially new architecture, authority, security, product, or scope decisions should be resolved separately. Author-side remediation cannot substitute for fresh independent review when that gate is required.
+Use only where the expected correction is objectively bounded by existing requirements and authority. Materially new architecture, authority, security, product, or scope decisions should be resolved separately. Merge, release/tag, deployment, unrelated repository mutation, infrastructure/provider mutation, and settings/credential/secret mutation are not granted by this workflow merely because a capability exists.
+
+Author-side remediation cannot substitute for fresh independent review when that gate is required. The action gateway is a workflow contract, not a new approval service, sandbox, or persisted policy object.
 
 ## Status
 

--- a/prompts/workflows/resolved-agent-run-context.md
+++ b/prompts/workflows/resolved-agent-run-context.md
@@ -2,26 +2,26 @@
 
 ## Purpose
 
-Define the reusable Promptbook contract for deriving the effective execution state of a governed agent operation from current authoritative inputs. The first supported operation is `/review`.
+Define the reusable Promptbook contract for deriving the effective execution state of a governed agent operation from current authoritative inputs. The explicitly supported operations are `/review` and `/fix`, each with its own capability and lifecycle profile under one common authority/evidence model.
 
 Promptbook is the canonical owner of this workflow contract. The context is ephemeral derived state, not a new durable authority source and not a replacement for repository-native instructions, issue or pull-request authority, immutable Git identity, CI evidence, or other durable records.
 
 ## When to use
 
-Use this contract before substantive `/review` adjudication so the review operates from explicit repository/work authority, immutable candidate identity, capability boundaries, instruction provenance, and required evidence rather than remembered conversation state.
+Use this contract before substantive `/review` adjudication and before substantive `/fix` mutation so the operation executes from explicit repository/work authority, candidate identity, capability boundaries, instruction provenance, and required evidence rather than remembered conversation state.
 
-Future workflows may reuse the same model only when their own authority and capability semantics are deliberately defined. This first slice does not generalise `/review` permissions to `/fix`, `/go`, or other operations.
+An operation may reuse the common model only when its own authority and capability semantics are deliberately defined here. Supporting `/fix` does not generalise `/review` permissions to mutation, and neither profile defines `/go` authority.
 
 ## Prompt
 
 ```text
-Before substantive review adjudication, resolve an ephemeral Resolved Agent Run Context from current authoritative inputs.
+Before substantive governed execution, resolve an ephemeral Resolved Agent Run Context from current authoritative inputs for the selected operation.
 
-Bind the operation to the repository, work item, immutable candidate where applicable, resolved authority sources, applicable repository instructions and their provenance, effective and prohibited capabilities, owner-decision boundaries, and required evidence.
+Bind the operation to the repository, work item, immutable candidate identity where applicable, resolved authority sources, applicable repository instructions and their provenance, effective and prohibited capabilities, owner-decision boundaries, and required evidence. For `/fix`, also bind the starting candidate, remediation scope, and required validation before substantive mutation.
 
-Treat the resolved context as derived execution state rather than a new authority source. Do not fill missing authority or evidence from conversation memory. Intersect available capabilities with the read-only review boundary, adding only the narrow review-publication capability explicitly carried by the governing review mode.
+Treat the resolved context as derived execution state rather than a new authority source. Do not fill missing authority or evidence from conversation memory. Technical capability availability may only narrow executable capability; it must never create authority.
 
-Collect bounded reconstructable evidence, distinguish static observation from executed and durable evidence, bind material findings and the disposition to the immutable candidate, and re-resolve candidate-specific state if that identity changes.
+Use the operation-specific capability profile and lifecycle below. Collect bounded reconstructable evidence, distinguish static observation from executed and durable evidence, and bind candidate-specific evidence to the immutable candidate for which it was actually observed.
 ```
 
 ## Core rule
@@ -30,7 +30,34 @@ A governed operation must execute from explicit, reconstructable authority and c
 
 The conversation may carry intent and navigation, but correctness must be reconstructable from current authoritative sources. Prior summaries and remembered conclusions are navigation aids only when the underlying authority or evidence can be refreshed directly.
 
-## Required context
+A technically available connector, shell, API, credential path, or other tool is not authority:
+
+```text
+tool available
+    ≠
+action authorised
+```
+
+## Common inputs and authority resolution
+
+Resolve the context from the authoritative inputs that apply to the operation. At minimum, consider:
+
+- platform safety and explicit current-user authority;
+- the Promptbook workflow selected for the operation;
+- repository-local instructions and mandatory policy;
+- the governing issue, pull request, design, specification, accepted plan, review finding, or other work-item authority;
+- the immutable candidate being reviewed or remediated where applicable;
+- current CI, checks, review state, and other decision-critical durable evidence.
+
+Conversation history may help locate those sources, but it is not a substitute for refreshing them when correctness depends on current state.
+
+Resolve the context from current authoritative inputs in precedence order appropriate to the repository and operation. Record enough provenance to identify where each applicable instruction or material rule came from. A resolved context does not create authority absent from those sources.
+
+If a required authority source cannot be resolved, fail closed or hand off according to the governing workflow rather than filling the gap from conversation memory.
+
+The representation may be textual or structured. It need not be committed for every run. Whatever representation is used, equivalent authoritative inputs must resolve to equivalent effective authority, candidate identity, capability boundaries, and evidence requirements for the same operation.
+
+## `/review` required context
 
 For `/review`, resolve at least:
 
@@ -47,30 +74,7 @@ owner_decision_boundaries
 required_evidence
 ```
 
-The representation may be textual or structured. It need not be committed for every run. Whatever representation is used, equivalent authoritative inputs must resolve to equivalent effective authority, candidate identity, capability boundaries, and evidence requirements.
-
-## Inputs
-
-Resolve the context from the authoritative inputs that apply to the operation. At minimum, consider:
-
-- platform safety and explicit current-user authority;
-- the Promptbook workflow selected for the operation;
-- repository-local instructions and mandatory policy;
-- the governing issue, pull request, design, specification, or other work-item authority;
-- the immutable candidate being assessed;
-- current CI, checks, review state, and other decision-critical durable evidence.
-
-Conversation history may help locate those sources, but it is not a substitute for refreshing them when correctness depends on current state.
-
-## Authority resolution
-
-Resolve the context from current authoritative inputs in precedence order appropriate to the repository and operation.
-
-Record enough provenance to identify where each applicable instruction or material rule came from. A resolved context does not create authority absent from those sources.
-
-If a required authority source cannot be resolved, fail closed or hand off according to the governing workflow rather than filling the gap from conversation memory.
-
-## Immutable candidate
+## Immutable review candidate
 
 Where the review target has an immutable Git identity, bind the context to the exact candidate commit or equivalent immutable revision actually inspected.
 
@@ -80,7 +84,7 @@ Immediately before review publication, refresh the candidate identity and reconc
 
 ## Review capability profile
 
-For the first `/review` slice, the effective capability model is logically equivalent to:
+For `/review`, the effective capability model is logically equivalent to:
 
 ```text
 ALLOW
@@ -115,20 +119,151 @@ review_capabilities =
 
 Ordinary router `/review` may additionally carry only the narrow review-publication capability already defined by the router. `/review --read-only` carries no review-record mutation capability.
 
+## `/fix` required context
+
+Before substantive `/fix` execution, resolve at least:
+
+```text
+operation
+repository_identity
+work_item_identity
+starting_candidate_identity
+resolved_authority_sources
+applicable_repository_instructions
+remediation_scope
+effective_capabilities
+prohibited_capabilities
+owner_decision_boundaries
+required_validation
+required_evidence
+```
+
+`starting_candidate_identity` is the immutable reviewed candidate or equivalent revision to which the blocking findings and remediation authority apply. `remediation_scope` is derived from the governing findings, task/design, accepted plan where applicable, repository instructions, and explicit current authority. It is not inferred merely from what a tool could change.
+
+`available_capabilities` and `authority_derived_capabilities` may be retained as intermediate derived sets when useful for reconstruction, but they are not new authority sources.
+
+## `/fix` capability derivation
+
+Derive `/fix` capability as monotonic narrowing:
+
+```text
+effective_fix_capabilities =
+    technically_available_capabilities
+    ∩
+    authority_derived_capabilities
+    ∩
+    FIX_OPERATION_CEILING
+```
+
+Technical availability can only remove executable capability; it cannot grant authority. Authority derived from current repository/task/user sources can authorise actions only within the `/fix` operation ceiling. Delegation or an external execution substrate may narrow the set further but must never widen it.
+
+The `/fix` operation ceiling is logically equivalent to:
+
+```text
+ALLOW
+- repository/work-item reads required for the remediation
+- bounded implementation mutation attributable to the resolved remediation scope
+- work-branch/candidate mutation required to produce the remediated candidate
+- PR/work-item update required to publish the resulting candidate or evidence when that publication is already authorised by the governing workflow
+- validation and evidence collection required by repository authority
+
+FORBID
+- merge
+- release or tag publication
+- deployment
+- unrelated repository mutation
+- infrastructure or provider mutation unless separately authorised by another governing contract
+- repository settings, credential, or secret mutation unless separately authorised by another governing contract
+- expansion of remediation scope merely because a tool is available
+
+BOUNDARY
+- any action beyond the governing remediation authority requires an explicit owner decision or separately established authority
+```
+
+A capability that exists in the environment but is outside the resolved authority or the operation ceiling is not an effective `/fix` capability.
+
+## `/fix` action gateway
+
+Before every material `/fix` action, classify its authority using this precedence:
+
+```text
+1. If higher-precedence authority or the /fix operation ceiling prohibits it:
+   FORBID
+
+2. Else if the action is not attributable to the resolved remediation scope,
+   or it requires missing product, architecture, security, scope, owner,
+   or other separate authority:
+   REQUIRE OWNER / SEPARATE AUTHORITY
+
+3. Else if current authoritative sources permit it within the resolved
+   remediation scope:
+   ALLOW
+
+4. Missing or ambiguous authority never defaults to ALLOW.
+```
+
+`FORBID` means the action cannot be performed under the resolved `/fix` authority. It does not claim that a later, independently established governing contract could never authorise an otherwise permissible action.
+
+Keep authority classification separate from execution feasibility. If an action is `ALLOW` but the required execution capability is unavailable, do not reclassify it as `REQUIRE OWNER / SEPARATE AUTHORITY` merely because a tool is missing. Follow the governing router's capability/external-action boundary without broadening authority. Likewise, technical availability never changes an unauthorised action into `ALLOW`.
+
+## `/fix` candidate transition
+
+Treat remediation as a transition between immutable candidate identities rather than changing one candidate context in place:
+
+```text
+FixRunContext(A)
+    + authorised bounded actions
+    → remediation
+    → FixResult(B, delta, validation, evidence, remaining boundaries)
+```
+
+`starting_candidate_identity` belongs to the resolved pre-mutation context for candidate A. `resulting_candidate_identity` belongs to the remediation result after candidate B exists.
+
+Immediately before the first material write, refresh the expected starting candidate. If the candidate identity changes, invalidate the stale candidate-specific context and re-resolve before applying findings to unexpected bytes. If unexpected external candidate movement is detected during remediation, fail closed and reconcile/re-resolve before continuing.
+
+Once changed bytes produce candidate B, prior candidate-specific review and validation attached to candidate A expire for B. They may remain historical evidence about A, but they must not silently transfer as review or validation of B.
+
+Run the required validation against candidate B and bind the observed result to `resulting_candidate_identity`. Where the governing workflow requires fresh substantive review, the context that authored or materially shaped B must preserve that fresh-context boundary rather than reviewing B as independent evidence.
+
+## `/fix` remediation result
+
+The resulting remediation record or hand-off should be reconstructable as the logical equivalent of:
+
+```text
+governing_finding_or_remediation_authority
+starting_candidate_identity
+bounded_implementation_delta
+resulting_candidate_identity
+validation_and_evidence
+remaining_boundaries
+next_governed_state
+```
+
+The record should make clear which material actions were `ALLOW`, which proposed actions were `REQUIRE OWNER / SEPARATE AUTHORITY` or `FORBID`, and which authorised actions could not be executed because of a capability boundary.
+
 ## Required evidence
 
-Resolve the evidence necessary to support the requested disposition before adjudicating. Evidence should be proportionate, bounded, and reconstructable. Depending on the claim, it may include:
+Resolve the evidence necessary to support the requested operation before adjudicating or declaring remediation complete. Evidence should be proportionate, bounded, and reconstructable. Depending on the claim, it may include:
 
 - an exact command or tool invocation and result status;
 - bounded relevant output;
 - a CI or check result bound to the candidate;
 - a reproducible test;
 - a static source observation;
-- an applicable repository-rule or authority citation.
+- an applicable repository-rule or authority citation;
+- for `/fix`, the bounded implementation delta and resulting candidate identity.
 
 Do not fabricate executed evidence where only static analysis occurred. Identify static observations as static. If a material claim requires execution that was not performed, represent that absence rather than implying the execution succeeded.
 
-## Evidence-bearing findings
+For evidence, distinguish at least:
+
+- `STATIC` — source, configuration, metadata, or rule observation without executing the claimed behaviour;
+- `EXECUTED` — a command, test, check, or tool action was actually run and its result observed;
+- `DURABLE` — repository-hosted CI, review, check, or other retained evidence was inspected.
+
+A finding or remediation record may use more than one evidence class. Do not upgrade one class into another merely to strengthen the conclusion.
+
+## Evidence-bearing review findings
 
 A material review finding should be reconstructable as the logical equivalent of:
 
@@ -145,19 +280,13 @@ confidence
 
 The human-facing review may remain concise. It does not need to print a verbose schema for every observation, but the decisive reasoning must retain enough provenance to reconstruct why the disposition applies to the bound candidate.
 
-For evidence, distinguish at least:
-
-- `STATIC` — source, configuration, metadata, or rule observation without executing the claimed behaviour;
-- `EXECUTED` — a command, test, check, or tool action was actually run and its result observed;
-- `DURABLE` — repository-hosted CI, review, check, or other retained evidence was inspected.
-
-A finding may use more than one evidence class. Do not upgrade one class into another merely to strengthen the conclusion.
-
 ## What it does
 
-Makes the effective `/review` execution state explicit and reconstructable without introducing a new durable per-run artefact. It separates authority from capability, binds candidate-specific reasoning to immutable identity, preserves repository-instruction provenance, and requires evidence-bearing findings whose decisive support can be distinguished as static, executed, or durable.
+Makes the effective execution state of supported governed operations explicit and reconstructable without introducing a new durable per-run artefact. It separates authority from capability, preserves repository-instruction provenance, and requires honest evidence classes bound to the candidate for which they were observed.
 
-It also keeps the existing Promptbook review-recording model intact: ordinary router `/review` may publish only the requested review record, while `/review --read-only` remains zero-write.
+For `/review`, it keeps the existing Promptbook review-recording model intact: ordinary router `/review` may publish only the requested review record, while `/review --read-only` remains zero-write.
+
+For `/fix`, it permits only bounded remediation mutation derived from current authority, classifies material actions before execution, distinguishes candidate A from candidate B, and prevents A-specific review or validation from silently carrying forward after bytes change.
 
 ## `/review` lifecycle
 
@@ -186,6 +315,37 @@ Before substantive adjudication:
 
 During review, collect only evidence permitted by the effective capability set and relevant to the governing contract. Before publication, refresh candidate identity and any decision-critical evidence that can stale.
 
+## `/fix` lifecycle
+
+A representative remediation should be reconstructable as:
+
+```text
+production routing
+→ resolved repository/work authority
+→ starting immutable candidate A
+→ applicable instruction provenance
+→ bounded remediation scope
+→ effective/prohibited capabilities
+→ pre-action gateway classification
+→ bounded ALLOW mutations only
+→ resulting immutable candidate B
+→ B-bound validation/evidence
+→ remediation record / remaining boundaries
+→ fresh-review boundary or other correct governed next state
+```
+
+Before substantive mutation:
+
+1. resolve the `/fix` context from current authoritative inputs;
+2. bind the exact governing findings and `starting_candidate_identity`;
+3. establish instruction and authority provenance;
+4. derive the bounded `remediation_scope`;
+5. derive effective/prohibited capabilities by monotonic narrowing;
+6. resolve `required_validation` and `required_evidence`;
+7. refresh candidate A immediately before the first material write.
+
+During remediation, classify each material action through the action gateway and execute only `ALLOW` actions that are actually available. After changed bytes produce B, invalidate A-specific review/validation for B, run the required validation against B, and record the resulting candidate/evidence without crossing a required fresh-review boundary.
+
 ## Delegation invariant
 
 Future delegated or child execution contexts must never gain authority merely through delegation:
@@ -194,11 +354,13 @@ Future delegated or child execution contexts must never gain authority merely th
 child_authority ⊆ parent_authority
 ```
 
-This issue does not introduce subagent infrastructure; the invariant is recorded so future implementations preserve the same authority model.
+An external execution substrate should receive only the resolved authorised subset needed for the delegated action. This contract does not introduce subagent infrastructure or make the substrate a workflow-policy owner.
 
 ## Boundaries / limitations
 
-This first contract does not define `/fix` or `/go` run contexts, a Switchboard schema, operating-system or network sandboxing, Guardian-style approval automation, native subagents, agentctl policy ownership, or Watchtower workflow ownership.
+This contract does not define `/go` run contexts, a new Switchboard schema, operating-system or network sandboxing, Guardian-style approval automation, native subagents, agentctl policy ownership, or Watchtower workflow ownership.
+
+It does not grant merge, release, tag, deployment, infrastructure/provider, settings, credential, secret, production, or unrelated mutation authority. Those actions require a separate governing contract where they are permitted at all.
 
 External mechanisms may enforce capability restrictions or collect evidence, but they do not become owners of Promptbook workflow policy.
 

--- a/prompts/workflows/resolved-agent-run-context.md
+++ b/prompts/workflows/resolved-agent-run-context.md
@@ -38,7 +38,7 @@ tool available
 action authorised
 ```
 
-## Common inputs and authority resolution
+## Inputs
 
 Resolve the context from the authoritative inputs that apply to the operation. At minimum, consider:
 

--- a/tests/test_resolved_agent_run_context.py
+++ b/tests/test_resolved_agent_run_context.py
@@ -149,7 +149,7 @@ class ResolvedAgentRunContextTests(unittest.TestCase):
         self.assertIn("if unexpected external candidate movement is detected", self.contract_lower)
 
     def test_candidate_a_review_and_validation_expire_for_b(self):
-        self.assertIn("candidate-a-specific review and validation", self.contract_lower)
+        self.assertIn("prior candidate-specific review and validation attached to candidate a expire for b", self.contract_lower)
         self.assertIn("must not silently transfer as review or validation of b", self.contract_lower)
         self.assertIn("bind the observed result to `resulting_candidate_identity`", self.contract_lower)
         self.assertIn("fresh-context boundary", self.contract_lower)

--- a/tests/test_resolved_agent_run_context.py
+++ b/tests/test_resolved_agent_run_context.py
@@ -15,12 +15,21 @@ class ResolvedAgentRunContextTests(unittest.TestCase):
             ROOT / "prompts" / "workflows" / "fresh-independent-review.md"
         ).read_text(encoding="utf-8")
         cls.fresh_lower = cls.fresh.lower()
+        cls.remediate = (
+            ROOT / "prompts" / "engineering" / "remediate-review-findings.md"
+        ).read_text(encoding="utf-8")
+        cls.remediate_lower = cls.remediate.lower()
 
     def test_promptbook_is_canonical_owner_and_context_is_ephemeral(self):
         self.assertIn("promptbook is the canonical owner", self.contract_lower)
         self.assertIn("ephemeral derived state", self.contract_lower)
         self.assertIn("not a new durable authority source", self.contract_lower)
         self.assertIn("conversation transcript as executable state", self.contract_lower)
+
+    def test_supported_operations_are_explicit_without_generalising_authority(self):
+        self.assertIn("explicitly supported operations are `/review` and `/fix`", self.contract_lower)
+        self.assertIn("supporting `/fix` does not generalise `/review` permissions", self.contract_lower)
+        self.assertIn("neither profile defines `/go` authority", self.contract_lower)
 
     def test_review_context_has_required_fields(self):
         for field in (
@@ -33,6 +42,23 @@ class ResolvedAgentRunContextTests(unittest.TestCase):
             "effective_capabilities",
             "prohibited_capabilities",
             "owner_decision_boundaries",
+            "required_evidence",
+        ):
+            self.assertIn(field, self.contract)
+
+    def test_fix_context_has_required_fields(self):
+        for field in (
+            "operation",
+            "repository_identity",
+            "work_item_identity",
+            "starting_candidate_identity",
+            "resolved_authority_sources",
+            "applicable_repository_instructions",
+            "remediation_scope",
+            "effective_capabilities",
+            "prohibited_capabilities",
+            "owner_decision_boundaries",
+            "required_validation",
             "required_evidence",
         ):
             self.assertIn(field, self.contract)
@@ -69,6 +95,65 @@ class ResolvedAgentRunContextTests(unittest.TestCase):
         self.assertIn("read_only_review_capabilities", self.contract_lower)
         self.assertIn("requires an explicit owner decision", self.contract_lower)
 
+    def test_fix_capabilities_are_monotonically_narrowed(self):
+        self.assertIn("effective_fix_capabilities", self.contract)
+        self.assertIn("technically_available_capabilities", self.contract)
+        self.assertIn("authority_derived_capabilities", self.contract)
+        self.assertIn("FIX_OPERATION_CEILING", self.contract)
+        self.assertIn("technical availability can only remove executable capability", self.contract_lower)
+        self.assertIn("it cannot grant authority", self.contract_lower)
+        self.assertIn("must never widen it", self.contract_lower)
+
+    def test_fix_operation_ceiling_allows_only_bounded_remediation(self):
+        for allowed in (
+            "repository/work-item reads required for the remediation",
+            "bounded implementation mutation attributable to the resolved remediation scope",
+            "work-branch/candidate mutation required to produce the remediated candidate",
+            "validation and evidence collection required by repository authority",
+        ):
+            self.assertIn(allowed, self.contract_lower)
+        for forbidden in (
+            "merge",
+            "release or tag publication",
+            "deployment",
+            "unrelated repository mutation",
+            "infrastructure or provider mutation",
+            "repository settings, credential, or secret mutation",
+            "expansion of remediation scope merely because a tool is available",
+        ):
+            self.assertIn(forbidden, self.contract_lower)
+
+    def test_fix_action_gateway_is_explicit_and_fail_closed(self):
+        self.assertIn("## `/fix` action gateway", self.contract)
+        self.assertIn("FORBID", self.contract)
+        self.assertIn("REQUIRE OWNER / SEPARATE AUTHORITY", self.contract)
+        self.assertIn("ALLOW", self.contract)
+        self.assertIn("missing or ambiguous authority never defaults to allow", self.contract_lower)
+        forbid_pos = self.contract.index("1. If higher-precedence authority")
+        owner_pos = self.contract.index("2. Else if the action is not attributable")
+        allow_pos = self.contract.index("3. Else if current authoritative sources permit it")
+        self.assertLess(forbid_pos, owner_pos)
+        self.assertLess(owner_pos, allow_pos)
+
+    def test_authority_classification_is_separate_from_execution_feasibility(self):
+        self.assertIn("keep authority classification separate from execution feasibility", self.contract_lower)
+        self.assertIn("do not reclassify it as `require owner / separate authority`", self.contract_lower)
+        self.assertIn("technical availability never changes an unauthorised action into `allow`", self.contract_lower)
+
+    def test_fix_candidate_transition_is_explicit(self):
+        self.assertIn("FixRunContext(A)", self.contract)
+        self.assertIn("FixResult(B, delta, validation, evidence, remaining boundaries)", self.contract)
+        self.assertIn("starting_candidate_identity", self.contract)
+        self.assertIn("resulting_candidate_identity", self.contract)
+        self.assertIn("immediately before the first material write", self.contract_lower)
+        self.assertIn("if unexpected external candidate movement is detected", self.contract_lower)
+
+    def test_candidate_a_review_and_validation_expire_for_b(self):
+        self.assertIn("candidate-a-specific review and validation", self.contract_lower)
+        self.assertIn("must not silently transfer as review or validation of b", self.contract_lower)
+        self.assertIn("bind the observed result to `resulting_candidate_identity`", self.contract_lower)
+        self.assertIn("fresh-context boundary", self.contract_lower)
+
     def test_instruction_provenance_and_evidence_are_reconstructable(self):
         self.assertIn("where each applicable instruction", self.contract_lower)
         self.assertIn("evidence should be proportionate, bounded, and reconstructable", self.contract_lower)
@@ -103,6 +188,19 @@ class ResolvedAgentRunContextTests(unittest.TestCase):
         ):
             self.assertIn(stage, self.contract_lower)
 
+    def test_fix_lifecycle_is_explicit(self):
+        for stage in (
+            "starting immutable candidate a",
+            "bounded remediation scope",
+            "effective/prohibited capabilities",
+            "pre-action gateway classification",
+            "bounded allow mutations only",
+            "resulting immutable candidate b",
+            "b-bound validation/evidence",
+            "fresh-review boundary or other correct governed next state",
+        ):
+            self.assertIn(stage, self.contract_lower)
+
     def test_fresh_review_integrates_context_before_adjudication(self):
         self.assertIn("before substantive adjudication", self.fresh_lower)
         self.assertIn("resolve the ephemeral resolved agent run context", self.fresh_lower)
@@ -111,9 +209,51 @@ class ResolvedAgentRunContextTests(unittest.TestCase):
         self.assertIn("evidence-bearing provenance", self.fresh_lower)
         self.assertIn("do not fabricate executed evidence", self.fresh_lower)
 
+    def test_remediation_integrates_fix_context_before_mutation(self):
+        self.assertIn("before substantive mutation", self.remediate_lower)
+        self.assertIn("resolve the `/fix` resolved agent run context", self.remediate_lower)
+        self.assertIn("resolved-agent-run-context.md", self.remediate)
+        self.assertIn("exact starting candidate identity", self.remediate_lower)
+        self.assertIn("bounded remediation scope", self.remediate_lower)
+        self.assertIn("required validation", self.remediate_lower)
+        self.assertIn("required evidence", self.remediate_lower)
+
+    def test_remediation_uses_action_gateway_and_preserves_authority_boundary(self):
+        self.assertIn("before each material action", self.remediate_lower)
+        for classification in (
+            "`ALLOW`",
+            "`REQUIRE OWNER / SEPARATE AUTHORITY`",
+            "`FORBID`",
+        ):
+            self.assertIn(classification, self.remediate)
+        self.assertIn("missing or ambiguous authority never defaults to `allow`", self.remediate_lower)
+        self.assertIn("technically available tool never grants authority", self.remediate_lower)
+        self.assertIn("execute only `allow` actions that are actually available", self.remediate_lower)
+
+    def test_remediation_record_is_bound_to_resulting_candidate(self):
+        for field in (
+            "starting candidate identity",
+            "bounded implementation delta",
+            "resulting candidate identity",
+            "validation/evidence bound to the resulting candidate",
+            "remaining boundaries and next governed state",
+        ):
+            self.assertIn(field, self.remediate_lower)
+        self.assertIn("candidate-a-specific review and validation do not silently transfer to b", self.remediate_lower)
+        self.assertIn("`STATIC`", self.remediate)
+        self.assertIn("`EXECUTED`", self.remediate)
+        self.assertIn("`DURABLE`", self.remediate)
+
+    def test_remediation_preserves_fresh_review_boundary(self):
+        self.assertIn("independent re-review is required", self.remediate_lower)
+        self.assertIn("hard fresh-context boundary", self.remediate_lower)
+        self.assertIn("next chat: /review <reviewed_candidate>", self.remediate_lower)
+        self.assertIn("author-side remediation as fresh approval evidence", self.remediate_lower)
+
     def test_delegation_cannot_expand_authority(self):
         self.assertIn("child_authority ⊆ parent_authority", self.contract)
         self.assertIn("never gain authority merely through delegation", self.contract_lower)
+        self.assertIn("resolved authorised subset", self.contract_lower)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Implements the accepted plan for #44 (issue comment `5465104029`).

- generalises the Resolved Agent Run Context into one common contract with explicit `/review` and `/fix` operation profiles;
- defines monotonic `/fix` capability narrowing and an authority-first `ALLOW` / `REQUIRE OWNER / SEPARATE AUTHORITY` / `FORBID` action gateway;
- models remediation as immutable candidate A → candidate B transition, invalidating A-specific review/validation for changed bytes and binding validation/evidence to B;
- integrates the contract into `remediate-review-findings.md` before substantive mutation;
- extends focused regression coverage while preserving existing `/review`, read-only review, review-publication, continuation, and fresh-context semantics.

## Scope

Changed only the planned files:

- `prompts/workflows/resolved-agent-run-context.md`
- `prompts/engineering/remediate-review-findings.md`
- `tests/test_resolved_agent_run_context.py`

No router, public command vocabulary, bootstrap, Switchboard, merge/release/deploy authority, or unrelated repository behaviour is changed.

## Validation

Required PR validation:

```text
python scripts/validate_promptbook.py
python -m unittest discover -s tests -p 'test_*.py' -v
```

The candidate must not be merged until those checks pass on the exact head and a genuinely fresh substantive review is completed.