### PR TITLE
Define executor capability projection contract

### DIFF
--- a/prompts/workflows/executor-capability-projection.md
+++ b/prompts/workflows/executor-capability-projection.md
@@ -1,0 +1,285 @@
+# Executor capability projection
+
+## Purpose
+
+Define the Promptbook contract for projecting a resolved agent run context into a bounded executor-facing capability profile. The profile lets an execution substrate enforce no more than the capabilities already authorised for the resolved `/review`, `/fix`, or `/go` operation.
+
+This contract is a companion to [Resolved agent run context](resolved-agent-run-context.md). Promptbook owns the workflow-side projection semantics. A consuming executor owns only its supported mechanisms, local safety policy, enforcement and evidence; it does not become a repository-policy, workflow-policy or owner-decision authority source.
+
+## Core invariant
+
+Projection may narrow authority but must never widen it:
+
+```text
+projected_executor_capabilities
+    ⊆
+resolved_effective_capabilities
+```
+
+A consuming executor may narrow again:
+
+```text
+actual_executor_capabilities =
+    projected_executor_capabilities
+    ∩
+    executor_supported_capabilities
+    ∩
+    executor_local_safety_policy
+```
+
+The executor-side intersection cannot add a capability absent from the Promptbook projection.
+
+Technical availability is never authority:
+
+```text
+executor has tool / credential / network / API access
+    ≠
+executor is authorised to expose or use it
+```
+
+## When to project
+
+Project an executor profile only when a resolved operation is delegating or exposing one or more material capabilities to an execution substrate.
+
+Do not create a profile merely because an executor exists. Advisory reasoning or work that remains entirely inside the current governed context does not acquire an executor profile unless a capability is actually being exposed or delegated.
+
+For `/go`, projection at a consequential gate is action-specific. Do not project one broad lifecycle profile containing every capability that might eventually be useful.
+
+## Required profile
+
+The representation may be textual or structured and does not need to be persisted for every run. It should be logically equivalent to the decision-critical subset of:
+
+```text
+profile_version
+operation
+repository_identity
+governing_work_or_objective_identity
+bound_state_identity
+resolved_context_identity_or_provenance
+allowed_capabilities
+denied_capabilities
+execution_constraints
+stale_or_expiry_conditions
+required_execution_evidence
+projection_provenance
+```
+
+`bound_state_identity` is the immutable candidate, lifecycle result, accepted proposal identity, or other sufficiently exact state against which the projected capability is valid.
+
+`execution_constraints` may describe bounded repository, branch, filesystem, network, credential, provider or external-service limits when those limits are decision-critical. The profile must not contain secret values or unnecessary environment state.
+
+The profile is derived execution state, not a durable authority source. If it conflicts with current authoritative inputs, current authoritative inputs win and the profile is stale.
+
+## Portable capability vocabulary
+
+Use the smallest capability vocabulary that preserves material effect boundaries. The initial portable classes are:
+
+```text
+repository_read
+work_item_read
+ci_evidence_read
+candidate_write
+work_item_evidence_update
+review_publish
+validation_execute
+workflow_dispatch
+merge
+release_publish
+deploy
+repository_settings_write
+credential_use
+external_filesystem_read
+external_filesystem_write
+network_access
+provider_mutation
+production_data_mutation
+```
+
+A concrete executor may use a more specific internal vocabulary, but it must map each executable effect back to one or more projected portable classes without weakening the Promptbook boundary.
+
+Do not infer broad capability from a narrower class. For example, `repository_read` does not imply `candidate_write`, and `merge` does not imply `release_publish` or `deploy`.
+
+## Projection from the action gateway
+
+For every material capability or exact action being delegated, preserve the resolved authority classification:
+
+```text
+ALLOW
+  → capability may be eligible for projection
+
+REQUIRE OWNER / SEPARATE AUTHORITY
+  → capability must not be projected as executable authority
+
+FORBID
+  → capability must not be projected
+```
+
+`ALLOW` is necessary but not sufficient. Project only capability needed for the current operation/action. An executor may then remove projected capability because of unsupported mechanisms, stronger local policy, guard failure or stale state.
+
+Keep authority and feasibility distinct. A capability denied by Promptbook authority is not the same result as a capability that is authorised but unsupported by the executor.
+
+## No ambient authority from environment state
+
+None of the following may widen a projection:
+
+- a connector, shell, API or plugin being installed;
+- repository write permission;
+- a credential, token or cloud identity being present;
+- network reachability;
+- executor support for a capability;
+- a previous operation having been authorised;
+- a prior approval whose bounded action has already been consumed; or
+- a previous successful execution.
+
+Credential, network or provider capability may be projected only when the resolved operation establishes both the action authority and the bounded need for that capability class. A profile must never expose credential capability merely because credentials exist.
+
+## Operation profiles
+
+### `/review --read-only`
+
+A representative projection may include:
+
+```text
+repository_read
+work_item_read
+ci_evidence_read
+```
+
+It must not include any write capability, including `review_publish`.
+
+### Ordinary `/review`
+
+A representative projection may include:
+
+```text
+repository_read
+work_item_read
+ci_evidence_read
+review_publish
+```
+
+`review_publish` is the narrow router-authorised review-record write only. It does not imply candidate mutation, workflow dispatch, merge, release or deployment.
+
+### `/fix`
+
+A representative bounded remediation projection may include:
+
+```text
+repository_read
+work_item_read
+candidate_write
+work_item_evidence_update
+validation_execute
+```
+
+It must not include `merge`, `release_publish` or `deploy` under the `/fix` operation ceiling. Provider, settings, credential or production mutation remains absent unless another separately governed contract has already made the exact action effective authority and the current Promptbook operation permits projection of that bounded effect.
+
+### `/go`
+
+A `/go` profile is derived for the exact next governed action. For example, independently authorised merge of candidate A may project `merge` bound to A, while `release_publish` and `deploy` remain absent.
+
+After merge creates result M, the A-bound profile is stale. A later release or deployment requires a newly resolved action gateway and a newly projected profile bound to the applicable resulting state and authority.
+
+## Identity and stale-profile invalidation
+
+Before execution, an executor must be able to verify that the profile still matches the target state and declared guards without reconstructing the full Promptbook workflow policy.
+
+Invalidate and re-project when a decision-critical input changes, including where applicable:
+
+- candidate or result identity;
+- governing work/objective authority;
+- accepted proposal identity or bounded approval state;
+- operation or operation ceiling;
+- required checks or other freshness-sensitive preconditions;
+- repository instructions or policy that affect the action; or
+- declared expiry/freshness bounds.
+
+Examples:
+
+```text
+/review profile for candidate A
+    ≠
+/review profile for candidate B
+```
+
+```text
+/fix profile bound to starting candidate A
+    must not authorise writes against moved candidate A'
+```
+
+```text
+/go merge profile for candidate A
+    ≠
+release or deploy profile for merge result M
+```
+
+A consumed approval is not a reusable profile input. If a proposal materially changes before execution, stale approval must be re-resolved before capability can be projected again.
+
+## Executor enforcement result
+
+The executor should return bounded evidence logically equivalent to:
+
+```text
+profile_identity
+bound_state_identity
+requested_capability
+enforcement_decision
+executor_capability_intersection
+execution_status
+result_identity_or_evidence
+limitations
+```
+
+Use distinct result classes when they affect governed continuation:
+
+- `PROFILE_DENIED` — the requested capability was not projected as executable authority;
+- `EXECUTOR_UNSUPPORTED` — the capability was projected but the executor cannot provide it;
+- `STALE_PROFILE` — decision-critical state no longer matches the profile;
+- `GUARD_MISMATCH` — a required execution guard failed;
+- `EXECUTED` — the bounded capability executed and result/evidence was observed.
+
+The shareable result must not include raw secret values, broad environment dumps or private diagnostic content merely because the executor can observe them.
+
+## Consumer contract
+
+A compliant executor consumer must:
+
+1. verify the profile version and bound identities it understands;
+2. reject unknown or materially ambiguous capability semantics rather than widening them;
+3. intersect the projected capabilities with supported capability and local safety policy;
+4. execute only the requested capability that survives that intersection and all required guards;
+5. never interpret arbitrary command text as authority when the projected contract names a bounded capability;
+6. return bounded enforcement evidence; and
+7. leave any next workflow, owner decision, merge/release/deploy progression or acceptance decision to the governing Promptbook/repository context.
+
+Executor-local policy may be stricter than Promptbook projection. It must not be weaker in a way that widens executable authority.
+
+## Delegation invariant
+
+Projection preserves the broader delegation rule:
+
+```text
+child_authority ⊆ parent_authority
+```
+
+A child or external executor profile must be a subset of the parent operation's current effective capabilities, further narrowed to the child action need. Delegation cannot refresh stale parent authority or manufacture new capability classes.
+
+This contract does not define native subagent infrastructure or a complete delegated-agent protocol.
+
+## Evidence and limitations
+
+Capability projection is itself a policy contract. Documentary presence is `STATIC` evidence. Tests exercising the contract are `EXECUTED` evidence. Repository-hosted checks or retained execution records are `DURABLE` evidence when inspected.
+
+Do not claim machine enforcement until a real executor has consumed the profile and demonstrated enforcement. A later executor implementation must be governed separately.
+
+## Boundaries / limitations
+
+This contract does not implement an executor, sandbox, network policy engine, credential broker, secret distributor, remote worker, OCI runner, deployment framework, provider policy or production mutation policy.
+
+It does not change the authority semantics of `/review`, `/fix`, or `/go`; it only projects their already-resolved effective capabilities into a form an executor can further restrict and enforce.
+
+External executors remain mechanisms, not Promptbook workflow-policy authorities.
+
+## Status
+
+`candidate`

--- a/prompts/workflows/executor-capability-projection.md
+++ b/prompts/workflows/executor-capability-projection.md
@@ -6,6 +6,36 @@ Define the Promptbook contract for projecting a resolved agent run context into 
 
 This contract is a companion to [Resolved agent run context](resolved-agent-run-context.md). Promptbook owns the workflow-side projection semantics. A consuming executor owns only its supported mechanisms, local safety policy, enforcement and evidence; it does not become a repository-policy, workflow-policy or owner-decision authority source.
 
+## When to use
+
+Use this contract only when a resolved operation is delegating or exposing one or more material capabilities to an execution substrate.
+
+Do not create a profile merely because an executor exists. Advisory reasoning or work that remains entirely inside the current governed context does not acquire an executor profile unless a capability is actually being exposed or delegated.
+
+For `/go`, projection at a consequential gate is action-specific. Do not project one broad lifecycle profile containing every capability that might eventually be useful.
+
+## Prompt
+
+```text
+Given a current Resolved Agent Run Context, project only the operation/action capabilities that are already effective authority and actually needed by the executor for this bounded step.
+
+Bind the projection to the exact decision-critical state and authority provenance from which it was derived. Preserve `ALLOW`, `REQUIRE OWNER / SEPARATE AUTHORITY`, and `FORBID`: only `ALLOW` capability may be eligible for projection, and neither tool availability nor executor-local support may add authority.
+
+Represent denied capability explicitly enough for a consuming executor to fail closed. Allow the executor to narrow the projected set further through its supported-capability and local-safety intersection, but never to widen it.
+
+Before execution, reject stale or mismatched profile state. After execution, return bounded evidence that distinguishes profile denial, executor unavailability, stale state, guard mismatch, and actual execution. Do not expose secrets or treat executor evidence as authority for a later workflow action.
+```
+
+## Inputs
+
+- the current Resolved Agent Run Context for `/review`, `/fix`, or `/go`;
+- the exact material action or bounded delegated step being considered;
+- the immutable candidate, lifecycle result, accepted proposal, or other decision-critical bound state;
+- the resolved action-gateway classification and current effective/prohibited capabilities;
+- any operation-specific filesystem, network, credential, provider, repository, branch, or external-service constraints that are already authoritative;
+- freshness, expiry, consumed-approval, or guard conditions that can invalidate execution; and
+- the bounded execution evidence required for safe governed continuation.
+
 ## Core invariant
 
 Projection may narrow authority but must never widen it:
@@ -36,14 +66,6 @@ executor has tool / credential / network / API access
     ≠
 executor is authorised to expose or use it
 ```
-
-## When to project
-
-Project an executor profile only when a resolved operation is delegating or exposing one or more material capabilities to an execution substrate.
-
-Do not create a profile merely because an executor exists. Advisory reasoning or work that remains entirely inside the current governed context does not acquire an executor profile unless a capability is actually being exposed or delegated.
-
-For `/go`, projection at a consequential gate is action-specific. Do not project one broad lifecycle profile containing every capability that might eventually be useful.
 
 ## Required profile
 
@@ -272,6 +294,12 @@ Capability projection is itself a policy contract. Documentary presence is `STAT
 
 Do not claim machine enforcement until a real executor has consumed the profile and demonstrated enforcement. A later executor implementation must be governed separately.
 
+## What it does
+
+Makes the already-resolved Promptbook authority boundary consumable by an executor without allowing the executor or environment to become a new authority source. It defines the portable profile, material capability vocabulary, state-binding and stale-profile rules, executor-side no-widening intersection, and bounded evidence needed to distinguish policy denial from unavailable or failed execution.
+
+It preserves the existing `/review`, `/fix`, and `/go` operation ceilings rather than creating new capability. A later executor can implement this contract independently and prove machine enforcement without requiring Promptbook to own the executor mechanism.
+
 ## Boundaries / limitations
 
 This contract does not implement an executor, sandbox, network policy engine, credential broker, secret distributor, remote worker, OCI runner, deployment framework, provider policy or production mutation policy.
@@ -282,4 +310,4 @@ External executors remain mechanisms, not Promptbook workflow-policy authorities
 
 ## Status
 
-`candidate`
+`experimental`

--- a/tests/test_executor_capability_projection.py
+++ b/tests/test_executor_capability_projection.py
@@ -1,0 +1,193 @@
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class ExecutorCapabilityProjectionTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.projection = (
+            ROOT / "prompts" / "workflows" / "executor-capability-projection.md"
+        ).read_text(encoding="utf-8")
+        cls.projection_lower = cls.projection.lower()
+        cls.context = (
+            ROOT / "prompts" / "workflows" / "resolved-agent-run-context.md"
+        ).read_text(encoding="utf-8")
+        cls.context_lower = cls.context.lower()
+
+    def test_projection_can_narrow_but_never_widen(self):
+        self.assertIn("projected_executor_capabilities", self.projection)
+        self.assertIn("resolved_effective_capabilities", self.projection)
+        self.assertIn("actual_executor_capabilities", self.projection)
+        self.assertIn("executor_supported_capabilities", self.projection)
+        self.assertIn("executor_local_safety_policy", self.projection)
+        self.assertIn("cannot add a capability absent", self.projection_lower)
+
+    def test_profile_is_derived_state_not_authority(self):
+        self.assertIn("derived execution state", self.projection_lower)
+        self.assertIn("not a durable authority source", self.projection_lower)
+        self.assertIn("technical availability is never authority", self.projection_lower)
+        self.assertIn("credential", self.projection_lower)
+        self.assertIn("network", self.projection_lower)
+
+    def test_required_profile_fields_are_explicit(self):
+        for field in (
+            "profile_version",
+            "operation",
+            "repository_identity",
+            "governing_work_or_objective_identity",
+            "bound_state_identity",
+            "resolved_context_identity_or_provenance",
+            "allowed_capabilities",
+            "denied_capabilities",
+            "execution_constraints",
+            "stale_or_expiry_conditions",
+            "required_execution_evidence",
+            "projection_provenance",
+        ):
+            self.assertIn(field, self.projection)
+
+    def test_portable_capability_vocabulary_preserves_material_effects(self):
+        for capability in (
+            "repository_read",
+            "work_item_read",
+            "ci_evidence_read",
+            "candidate_write",
+            "work_item_evidence_update",
+            "review_publish",
+            "validation_execute",
+            "workflow_dispatch",
+            "merge",
+            "release_publish",
+            "deploy",
+            "repository_settings_write",
+            "credential_use",
+            "network_access",
+            "provider_mutation",
+            "production_data_mutation",
+        ):
+            self.assertIn(capability, self.projection)
+        self.assertIn("does not imply `release_publish` or `deploy`", self.projection_lower)
+
+    def test_action_gateway_classification_controls_projection(self):
+        self.assertIn("ALLOW", self.projection)
+        self.assertIn("REQUIRE OWNER / SEPARATE AUTHORITY", self.projection)
+        self.assertIn("FORBID", self.projection)
+        self.assertIn("must not be projected as executable authority", self.projection_lower)
+        self.assertIn("capability must not be projected", self.projection_lower)
+
+    def test_review_read_only_projects_no_write(self):
+        section = self.projection[
+            self.projection.index("### `/review --read-only`") :
+            self.projection.index("### Ordinary `/review`")
+        ]
+        self.assertIn("repository_read", section)
+        self.assertIn("work_item_read", section)
+        self.assertIn("ci_evidence_read", section)
+        self.assertIn("must not include any write capability", section.lower())
+        self.assertIn("`review_publish`", section)
+
+    def test_ordinary_review_projects_only_narrow_publication_write(self):
+        section = self.projection[
+            self.projection.index("### Ordinary `/review`") :
+            self.projection.index("### `/fix`")
+        ]
+        self.assertIn("review_publish", section)
+        for forbidden in (
+            "candidate mutation",
+            "workflow dispatch",
+            "merge",
+            "release",
+            "deployment",
+        ):
+            self.assertIn(forbidden, section.lower())
+
+    def test_fix_projects_candidate_write_but_not_merge_release_deploy(self):
+        section = self.projection[
+            self.projection.index("### `/fix`") :
+            self.projection.index("### `/go`")
+        ]
+        self.assertIn("candidate_write", section)
+        self.assertIn("validation_execute", section)
+        self.assertIn("must not include `merge`, `release_publish` or `deploy`", section.lower())
+
+    def test_go_projection_is_action_specific(self):
+        section = self.projection[self.projection.index("### `/go`") :]
+        self.assertIn("exact next governed action", section.lower())
+        self.assertIn("merge", section)
+        self.assertIn("release_publish", section)
+        self.assertIn("deploy", section)
+        self.assertIn("newly projected profile", section.lower())
+
+    def test_environment_state_cannot_widen_projection(self):
+        for ambient in (
+            "connector",
+            "shell",
+            "credential",
+            "token",
+            "network reachability",
+            "repository write permission",
+            "executor support",
+            "previous successful execution",
+        ):
+            self.assertIn(ambient, self.projection_lower)
+        self.assertIn("may widen a projection", self.projection_lower)
+
+    def test_profile_is_invalidated_by_material_state_change(self):
+        self.assertIn("invalidate and re-project", self.projection_lower)
+        self.assertIn("candidate or result identity", self.projection_lower)
+        self.assertIn("accepted proposal identity", self.projection_lower)
+        self.assertIn("consumed approval", self.projection_lower)
+        self.assertIn("stale approval", self.projection_lower)
+        self.assertIn("moved candidate a'", self.projection_lower)
+
+    def test_executor_results_distinguish_authority_and_feasibility(self):
+        for result in (
+            "PROFILE_DENIED",
+            "EXECUTOR_UNSUPPORTED",
+            "STALE_PROFILE",
+            "GUARD_MISMATCH",
+            "EXECUTED",
+        ):
+            self.assertIn(result, self.projection)
+        self.assertIn("not the same result", self.projection_lower)
+
+    def test_enforcement_evidence_has_required_shape(self):
+        for field in (
+            "profile_identity",
+            "bound_state_identity",
+            "requested_capability",
+            "enforcement_decision",
+            "executor_capability_intersection",
+            "execution_status",
+            "result_identity_or_evidence",
+            "limitations",
+        ):
+            self.assertIn(field, self.projection)
+        self.assertIn("must not include raw secret values", self.projection_lower)
+
+    def test_executor_consumer_is_not_policy_owner(self):
+        self.assertIn("does not become a repository-policy", self.projection_lower)
+        self.assertIn("external executors remain mechanisms", self.projection_lower)
+        self.assertIn("never interpret arbitrary command text as authority", self.projection_lower)
+
+    def test_delegation_cannot_widen_parent_authority(self):
+        self.assertIn("child_authority ⊆ parent_authority", self.projection)
+        self.assertIn("subset of the parent operation's current effective capabilities", self.projection_lower)
+        self.assertIn("cannot refresh stale parent authority", self.projection_lower)
+
+    def test_projection_does_not_change_existing_operation_authority(self):
+        self.assertIn("does not change the authority semantics", self.projection_lower)
+        for operation in ("`/review`", "`/fix`", "`/go`"):
+            self.assertIn(operation, self.projection)
+            self.assertIn(operation, self.context)
+        self.assertIn("technical availability never changes an unauthorised action", self.context_lower)
+
+    def test_machine_enforcement_is_not_claimed_before_executor_proof(self):
+        self.assertIn("do not claim machine enforcement", self.projection_lower)
+        self.assertIn("later executor implementation must be governed separately", self.projection_lower)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements #48 by defining the portable Promptbook contract that projects an already-resolved `/review`, `/fix`, or `/go` capability state into a bounded executor-facing profile.

The change deliberately does **not** implement an executor. It keeps Promptbook as the workflow-side owner of projection semantics and leaves executor support, local safety policy, enforcement/evidence mechanics, agentctl integration, remote execution, sandboxing, credentials and deployment separately governed.

## Authority / anchors

- Governing issue: #48
- Trusted base: `6ae5f32037816f96079e707d17230b5582968eb5`
- Exact candidate: `fb5ec72a401c76f235c136fde373a138c24d7fdd`
- Praxis architectural rationale: `8ft0-ai/praxis@c4f117bb214c279fd9fe025027f5afe808b418a8`
- Praxis practice: `praxis/authority-governed-agent-execution/v0.1`

## Scope

Exactly two new files:

- `prompts/workflows/executor-capability-projection.md`
- `tests/test_executor_capability_projection.py`

The existing resolved run-context contract is intentionally not rewritten: it already establishes that an external execution substrate receives only the resolved authorised subset and may narrow but never widen it. The new companion contract makes that projection boundary explicit and testable while preserving the established `/review`, `/fix`, and `/go` semantics.

## Contract introduced

Core invariant:

```text
projected_executor_capabilities
    ⊆
resolved_effective_capabilities
```

Executor-local enforcement may narrow again:

```text
actual_executor_capabilities =
    projected_executor_capabilities
    ∩
    executor_supported_capabilities
    ∩
    executor_local_safety_policy
```

The contract defines:

- the standard Promptbook workflow-document shape (`Purpose`, `When to use`, `Prompt`, `Inputs`, `What it does`, boundaries and status);
- a portable profile shape and material capability vocabulary;
- projection semantics for `ALLOW`, `REQUIRE OWNER / SEPARATE AUTHORITY`, and `FORBID`;
- no ambient authority from tools, credentials, network or environment state;
- operation-specific examples for `/review --read-only`, ordinary `/review`, `/fix`, and action-specific `/go`;
- exact-state binding and stale-profile invalidation;
- bounded approval consumption across projected capability;
- executor result classes that distinguish authority denial from unsupported capability, stale state and guard mismatch;
- bounded enforcement evidence; and
- the delegation invariant `child_authority ⊆ parent_authority`.

The document explicitly does not claim machine enforcement before a real executor consumes the profile under separate authority.

## Regression coverage

The new unittest suite covers:

- no-widening projection and executor-local narrowing;
- required profile fields and capability classes;
- `/review --read-only` zero-write projection;
- ordinary `/review` narrow review-publication write;
- `/fix` candidate-write allowed while merge/release/deploy remain absent;
- action-specific `/go` projection;
- `REQUIRE OWNER` / `FORBID` exclusion from executable projection;
- environment/tool/credential availability not creating authority;
- stale candidate/result/proposal and consumed-approval invalidation;
- distinct `PROFILE_DENIED`, `EXECUTOR_UNSUPPORTED`, `STALE_PROFILE`, `GUARD_MISMATCH`, and `EXECUTED` outcomes;
- enforcement evidence shape;
- executor-not-policy-owner boundary; and
- delegation no-widening.

## Validation / evidence

Final exact base-to-head comparison:

- base: `6ae5f32037816f96079e707d17230b5582968eb5`
- head: `fb5ec72a401c76f235c136fde373a138c24d7fdd`
- status: ahead
- 3 commits ahead / 0 behind
- exactly 2 changed files

`Validate Promptbook` run `33333423711` completed **successfully** on the exact final candidate. Job `99315978774` passed both:

- `Validate public prompt contract`
- `Run validator tests`

The earlier superseded candidate `04ce1ed520b79724576802c9e94b256a3891c790` produced failed run `33333364767` because the new workflow document did not yet use the repository-required standard headings/status vocabulary. That negative evidence was retained and remediated without weakening the capability-projection requirements.

Immediately before this hand-off, `main` remains the trusted base `6ae5f32037816f96079e707d17230b5582968eb5`.

No merge, release, deployment, agentctl mutation, executor implementation, credential operation, infrastructure/provider mutation or production action is authorised or performed by this PR.

## Review boundary

This context authored and remediated the candidate and is not fresh for substantive independent review. The next required gate is a genuinely fresh `/review` of exact PR #49 head `fb5ec72a401c76f235c136fde373a138c24d7fdd`.

Closes #48