### PR TITLE
Make the prompt index complete

### DIFF
--- a/prompts/README.md
+++ b/prompts/README.md
@@ -15,8 +15,11 @@ Promptbook is organised by the task a user wants to perform.
 - [Autonomous progression](workflows/autonomous-progression.md)
 - [Capability availability overrides](workflows/capability-availability-overrides.md)
 - [Documentation assessment workflow](workflows/documentation-assessment.md)
+- [Executor capability projection](workflows/executor-capability-projection.md)
 - [Fresh independent review](workflows/fresh-independent-review.md)
 - [Next-session handover](workflows/next-session-handover.md)
+- [Operational artifact hand-off](workflows/operational-artifact-handoff.md)
+- [Resolved agent run context](workflows/resolved-agent-run-context.md)
 
 ## Documentation
 

--- a/scripts/validate_promptbook.py
+++ b/scripts/validate_promptbook.py
@@ -49,6 +49,12 @@ def section(text: str, heading: str) -> str:
     return text[start:] if next_heading < 0 else text[start:next_heading]
 
 
+def published_prompt_files(prompt_root: Path) -> list[Path]:
+    return sorted(
+        path for path in prompt_root.rglob("*.md") if path.name != "README.md"
+    )
+
+
 def validate_prompt_file(path: Path) -> list[str]:
     errors: list[str] = []
     text = path.read_text(encoding="utf-8")
@@ -77,6 +83,36 @@ def validate_prompt_file(path: Path) -> list[str]:
     if any(token in text for token in ("TODO", "TBD", "FIXME")):
         errors.append(f"{path}: unresolved TODO/TBD/FIXME marker")
 
+    return errors
+
+
+def validate_prompt_index(prompt_root: Path) -> list[str]:
+    index_path = prompt_root / "README.md"
+    if not index_path.exists():
+        return [f"missing prompt index: {index_path}"]
+
+    index_text = index_path.read_text(encoding="utf-8")
+    prompt_root_resolved = prompt_root.resolve()
+    indexed: set[Path] = set()
+
+    for raw in LINK_RE.findall(index_text):
+        target = raw.split("#", 1)[0].strip()
+        if not target or target.startswith(("http://", "https://", "mailto:")):
+            continue
+        resolved = (index_path.parent / unquote(target)).resolve()
+        try:
+            resolved.relative_to(prompt_root_resolved)
+        except ValueError:
+            continue
+        if resolved.suffix == ".md" and resolved.name != "README.md":
+            indexed.add(resolved)
+
+    errors: list[str] = []
+    for path in published_prompt_files(prompt_root):
+        resolved = path.resolve()
+        if resolved not in indexed:
+            relative = path.relative_to(prompt_root).as_posix()
+            errors.append(f"{index_path}: published prompt missing from index: {relative}")
     return errors
 
 
@@ -113,14 +149,15 @@ def validate_repository(root: Path = ROOT) -> list[str]:
             errors.append(f"missing required path: {relative}")
 
     prompt_root = root / "prompts"
-    prompt_files = sorted(
-        path for path in prompt_root.rglob("*.md") if path.name != "README.md"
-    ) if prompt_root.exists() else []
+    prompt_files = published_prompt_files(prompt_root) if prompt_root.exists() else []
     if len(prompt_files) < 8:
         errors.append(f"expected at least 8 published prompts, found {len(prompt_files)}")
 
     for path in prompt_files:
         errors.extend(validate_prompt_file(path))
+
+    if prompt_root.exists():
+        errors.extend(validate_prompt_index(prompt_root))
 
     public_text_paths = set(root.rglob("*.md"))
     bootstrap = root / "BOOTSTRAP"

--- a/tests/test_validate_promptbook.py
+++ b/tests/test_validate_promptbook.py
@@ -69,6 +69,65 @@ class PromptbookValidationTests(unittest.TestCase):
             errors = MODULE.validate_text_safety(path, "source: ai-prompt-library")
             self.assertTrue(errors)
 
+    def test_prompt_index_lists_all_published_prompts(self):
+        prompt_root = ROOT / "prompts"
+        index_text = (prompt_root / "README.md").read_text(encoding="utf-8")
+
+        self.assertEqual([], MODULE.validate_prompt_index(prompt_root))
+        for target in (
+            "workflows/resolved-agent-run-context.md",
+            "workflows/executor-capability-projection.md",
+            "workflows/operational-artifact-handoff.md",
+        ):
+            self.assertIn(target, index_text)
+
+        workflow_lines = [
+            line
+            for line in MODULE.section(index_text, "Workflows").splitlines()
+            if line.strip()
+        ]
+        self.assertTrue(workflow_lines[0].startswith("- [Workflow router"))
+
+    def test_prompt_index_rejects_omitted_published_prompt(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            prompt_root = Path(tmp) / "prompts"
+            workflow_root = prompt_root / "workflows"
+            workflow_root.mkdir(parents=True)
+            (prompt_root / "README.md").write_text(
+                "# Prompts\n\n## Workflows\n\n",
+                encoding="utf-8",
+            )
+            (workflow_root / "missing.md").write_text(
+                "# Missing\n\n"
+                "## Purpose\nX\n\n## When to use\nX\n\n"
+                "## Prompt\n```text\nDo X\n```\n\n"
+                "## Inputs\nNone.\n\n## What it does\nX\n\n"
+                "## Boundaries / limitations\nX\n\n## Status\n`tested`\n",
+                encoding="utf-8",
+            )
+
+            errors = MODULE.validate_prompt_index(prompt_root)
+            self.assertTrue(
+                any(
+                    "published prompt missing from index: workflows/missing.md" in error
+                    for error in errors
+                )
+            )
+
+    def test_prompt_index_excludes_readme_support_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            prompt_root = Path(tmp) / "prompts"
+            workflow_root = prompt_root / "workflows"
+            workflow_root.mkdir(parents=True)
+            (prompt_root / "README.md").write_text("# Prompts\n", encoding="utf-8")
+            (workflow_root / "README.md").write_text(
+                "# Workflow support index\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual([], MODULE.published_prompt_files(prompt_root))
+            self.assertEqual([], MODULE.validate_prompt_index(prompt_root))
+
     def test_workflow_router_contract(self):
         text = (ROOT / "prompts" / "workflows" / "README.md").read_text(encoding="utf-8")
         lower = text.lower()


### PR DESCRIPTION
Closes #57.

## Summary

- add the three omitted reusable workflow contracts to `prompts/README.md` while keeping the workflow router first;
- factor the existing published-prompt discovery rule into `published_prompt_files()` and validate that every published prompt appears in the collection index;
- add deterministic regressions for complete indexing, omitted-prompt failure, and README/support-index exclusion.

## Scope

This candidate changes only:

- `prompts/README.md`
- `scripts/validate_promptbook.py`
- `tests/test_validate_promptbook.py`

It does not change workflow semantics, maturity/status labels, shorthand commands, bootstrap text, release notes, consumer state, Switchboard, or lifecycle authority.

## Exact candidate and validation

- base `main`: `a81871e4aaf69d9643d0b6a633ef53c4d4ce1a34`
- head: `f2069af86804ea7466a70e3363c403f19889b296`
- implementation branch: `feat/57-prompt-index-completeness`
- changed files: 3
- `Validate Promptbook` run: `33572786057`
- validation job: `100070128453` — `success`
- `Validate public prompt contract` — `success`
- `Run validator tests` — `success`

The authoring context is not fresh independent review evidence for its own candidate. A genuinely fresh substantive review of this exact head remains required before merge. No merge or release authority is claimed by this implementation record.